### PR TITLE
Add per-podcast Nostr feed: show kind:1 notes from any client

### DIFF
--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -5,6 +5,7 @@ import { useApp } from '@/lib/store';
 import { resolvePublishRelays, schedulePublishFavorites } from '@/lib/nostr';
 import { BoostModal } from './boost-modal';
 import { BoltIcon } from './icons';
+import { PodcastNostrFeed } from './podcast-nostr';
 
 function FavHeart({ podcast }: { podcast: Podcast }) {
   const guid = podcast.podcastGuid;
@@ -254,6 +255,10 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
           );
         })}
       </ul>
+
+      {data.podcast.podcastGuid && (
+        <PodcastNostrFeed podcastGuid={data.podcast.podcastGuid} />
+      )}
 
       {showBoostOpen && data.podcast && showHasValue && (
         <BoostModal

--- a/components/podcast-nostr.tsx
+++ b/components/podcast-nostr.tsx
@@ -1,0 +1,136 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { fetchPodcastNotes, shortNpub, type DiscoveredNote } from '@/lib/nostr';
+
+function timeAgo(unixSec: number): string {
+  const diff = Date.now() / 1000 - unixSec;
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 86400 * 30) return `${Math.floor(diff / 86400)}d ago`;
+  return new Date(unixSec * 1000).toLocaleDateString();
+}
+
+function NoteCard({ note }: { note: DiscoveredNote }) {
+  const name =
+    note.author?.display_name?.trim() ||
+    note.author?.name?.trim() ||
+    shortNpub(note.npub);
+  const sats =
+    note.amountMsat && note.amountMsat > 0
+      ? Math.round(note.amountMsat / 1000)
+      : null;
+
+  return (
+    <article className="card p-3 flex gap-3">
+      {note.author?.picture ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={note.author.picture}
+          alt=""
+          className="w-9 h-9 rounded-full object-cover border border-bone/20 flex-shrink-0"
+        />
+      ) : (
+        <div className="w-9 h-9 rounded-full border border-bone/20 bg-line flex-shrink-0" />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap text-xs">
+          <a
+            href={`https://njump.me/${note.npub}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-display text-sm text-bone hover:text-bolt truncate"
+            title={note.npub}
+          >
+            {name}
+          </a>
+          <span className="text-muted">· {timeAgo(note.createdAt)}</span>
+          {note.isBoost && sats !== null && (
+            <span className="stamp text-bolt border-bolt/60">⚡ {sats} sats</span>
+          )}
+          {note.isBoost && sats === null && (
+            <span className="stamp text-bolt border-bolt/60">⚡ boost</span>
+          )}
+          {note.client && (
+            <span className="text-muted">via {note.client}</span>
+          )}
+        </div>
+        <p className="text-sm text-bone whitespace-pre-wrap break-words mt-1">
+          {note.content}
+        </p>
+        <a
+          href={`https://njump.me/${note.nevent}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block text-[11px] text-muted hover:text-nostr mt-2"
+        >
+          view on nostr →
+        </a>
+      </div>
+    </article>
+  );
+}
+
+/**
+ * Renders every public kind:1 note from any author tagged with this podcast's
+ * NIP-73 `podcast:guid:` identifier. Loads on first mount; user can press
+ * Refresh to re-query.
+ */
+export function PodcastNostrFeed({ podcastGuid }: { podcastGuid: string }) {
+  const [notes, setNotes] = useState<DiscoveredNote[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setErr(null);
+    try {
+      const result = await fetchPodcastNotes(podcastGuid);
+      setNotes(result);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'failed to load nostr feed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    setNotes(null);
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [podcastGuid]);
+
+  return (
+    <section className="mt-8">
+      <header className="flex items-center justify-between border-b border-bone/15 pb-2 mb-3">
+        <h3 className="font-display text-lg">
+          <span className="text-nostr">#</span> Boosts &amp; chatter on Nostr
+        </h3>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="btn-ghost text-xs"
+          title="Re-query relays"
+        >
+          {loading ? 'loading…' : 'refresh'}
+        </button>
+      </header>
+      {err && <p className="text-sm text-red-400">{err}</p>}
+      {!err && notes === null && loading && (
+        <p className="text-sm text-muted">searching nostr relays…</p>
+      )}
+      {!err && notes !== null && notes.length === 0 && (
+        <p className="text-sm text-muted">
+          no nostr notes tagged this podcast yet — be the first to boost.
+        </p>
+      )}
+      {!err && notes !== null && notes.length > 0 && (
+        <div className="space-y-2">
+          {notes.map((n) => (
+            <NoteCard key={n.id} note={n} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/lib/nostr/discover.ts
+++ b/lib/nostr/discover.ts
@@ -1,0 +1,127 @@
+import { nip19, type Event } from 'nostr-tools';
+import { withPool } from './pool';
+import { DISCOVERY_RELAYS } from './relays';
+import type { ProfileMetadata } from './auth';
+
+export interface DiscoveredNote {
+  id: string;
+  pubkey: string;
+  npub: string;
+  nevent: string;          // bech32-encoded for client deep-links (njump.me/<nevent>)
+  createdAt: number;       // unix seconds
+  content: string;
+  amountMsat: number | null;
+  client: string | null;
+  isBoost: boolean;        // `t:boostagram` tag OR a positive `amount` tag
+  episodeGuids: string[];  // any podcast:item:guid: refs on the note
+  author: ProfileMetadata | null;
+}
+
+interface FetchOpts {
+  relays?: string[];
+  /** Cap on raw kind:1 events fetched; default 100. */
+  limit?: number;
+}
+
+/**
+ * Fetch every kind:1 note tagged with NIP-73 `podcast:guid:<podcastGuid>` from
+ * the given relays. Resolves each unique author's kind:0 metadata in a single
+ * follow-up query so the UI can render avatar + display_name without N+1
+ * round-trips. Returns notes sorted newest-first, deduped by event id.
+ */
+export async function fetchPodcastNotes(
+  podcastGuid: string,
+  opts: FetchOpts = {},
+): Promise<DiscoveredNote[]> {
+  const relays = opts.relays ?? DISCOVERY_RELAYS;
+  const limit = opts.limit ?? 100;
+
+  return withPool(relays, async (pool) => {
+    let events: Event[] = [];
+    try {
+      events = await pool.querySync(relays, {
+        kinds: [1],
+        '#i': [`podcast:guid:${podcastGuid}`],
+        limit,
+      });
+    } catch {
+      return [];
+    }
+    if (!events.length) return [];
+
+    // Dedupe by id (relays often return overlapping copies) and sort newest first.
+    const byId = new Map<string, Event>();
+    for (const e of events) byId.set(e.id, e);
+    const unique = Array.from(byId.values()).sort(
+      (a, b) => b.created_at - a.created_at,
+    );
+
+    const authors = Array.from(new Set(unique.map((e) => e.pubkey)));
+    const profiles = await fetchProfiles(pool, relays, authors);
+
+    return unique.map((e) => {
+      const amountTag = e.tags.find((t) => t[0] === 'amount')?.[1];
+      const amountMsat = amountTag ? Number(amountTag) : null;
+      const client = e.tags.find((t) => t[0] === 'client')?.[1] ?? null;
+      // Different apps tag boosts differently: BoostMeBitch and Helipad-style
+      // aggregators emit `t:boostagram`; some clients (Fountain, Wavlake
+      // variants) may omit it but still emit a positive `amount` tag. Treat
+      // either as a boost so the ⚡ stamp shows up consistently.
+      const isBoost =
+        e.tags.some((t) => t[0] === 't' && (t[1] === 'boostagram' || t[1] === 'value4value')) ||
+        (Number.isFinite(amountMsat) && (amountMsat ?? 0) > 0);
+      const episodeGuids = e.tags
+        .filter((t) => t[0] === 'i' && t[1]?.startsWith('podcast:item:guid:'))
+        .map((t) => t[1].slice('podcast:item:guid:'.length));
+      return {
+        id: e.id,
+        pubkey: e.pubkey,
+        npub: nip19.npubEncode(e.pubkey),
+        nevent: nip19.neventEncode({
+          id: e.id,
+          relays: relays.slice(0, 3),
+          author: e.pubkey,
+        }),
+        createdAt: e.created_at,
+        content: e.content,
+        amountMsat: Number.isFinite(amountMsat) ? amountMsat : null,
+        client,
+        isBoost,
+        episodeGuids,
+        author: profiles.get(e.pubkey) ?? null,
+      };
+    });
+  });
+}
+
+async function fetchProfiles(
+  pool: import('nostr-tools').SimplePool,
+  relays: string[],
+  authors: string[],
+): Promise<Map<string, ProfileMetadata>> {
+  const out = new Map<string, ProfileMetadata>();
+  if (!authors.length) return out;
+  let events: Event[] = [];
+  try {
+    events = await pool.querySync(relays, {
+      kinds: [0],
+      authors,
+    });
+  } catch {
+    return out;
+  }
+  // Newest kind:0 wins per pubkey.
+  const newest = new Map<string, Event>();
+  for (const e of events) {
+    const prev = newest.get(e.pubkey);
+    if (!prev || e.created_at > prev.created_at) newest.set(e.pubkey, e);
+  }
+  for (const [pubkey, e] of newest) {
+    try {
+      out.set(pubkey, JSON.parse(e.content) as ProfileMetadata);
+    } catch {
+      // ignore unparseable content
+    }
+  }
+  return out;
+}

--- a/lib/nostr/index.ts
+++ b/lib/nostr/index.ts
@@ -13,9 +13,15 @@ export { fetchProfile } from './profile';
 
 export {
   DEFAULT_RELAYS,
+  DISCOVERY_RELAYS,
   fetchRelayList,
   resolvePublishRelays,
 } from './relays';
+
+export {
+  fetchPodcastNotes,
+  type DiscoveredNote,
+} from './discover';
 
 export {
   publishBoostNote,

--- a/lib/nostr/relays.ts
+++ b/lib/nostr/relays.ts
@@ -9,6 +9,15 @@ export const DEFAULT_RELAYS = [
   'wss://relay.nostr.band',
 ];
 
+// Read-only relay set used for discovering other users' notes (kind:1) tagged
+// with NIP-73 podcast identifiers. Fountain's relay aggregates a lot of
+// podcast-tagged activity that doesn't always make it to the general-purpose
+// relays in DEFAULT_RELAYS, so it gets added here.
+export const DISCOVERY_RELAYS = [
+  ...DEFAULT_RELAYS,
+  'wss://relay.fountain.fm',
+];
+
 // NIP-65 relay list (kind:10002). We only consume the write side — we never
 // read events from arbitrary relays based on someone's read list, so the
 // parser drops it.


### PR DESCRIPTION
A new "Boosts & chatter on Nostr" panel below the episode list queries
kind:1 notes filtered by NIP-73 #i: podcast:guid:<guid> from a discovery
relay set (DEFAULT_RELAYS + relay.fountain.fm). Author kind:0 metadata is
resolved in a single batch follow-up query so the avatar + display_name
render without N+1 round-trips. Boost detection accepts either t:boostagram
/ t:value4value or a positive amount tag, so notes from any app using the
shared Podcasting 2.0 tagging convention (Fountain, Wavlake, Castamatic,
BoostMeBitch, etc.) all get the ⚡ stamp.