### PR TITLE
Scaffold Spark rail, BoostBox sidechannel, and Nostr-backed wallet backup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,11 @@
 PODCAST_INDEX_KEY=
 PODCAST_INDEX_SECRET=
 
+# Breez Spark SDK — get a key at https://breez.technology/sdk/
+# Required for the Spark payment rail. Public-flagged because the SDK
+# initializes in the browser (self-custodial wallet, key gates SDK
+# usage, not user wallets).
+NEXT_PUBLIC_BREEZ_API_KEY=
+
 # Optional: app identity for Podcast Index User-Agent
 APP_NAME=boostmebitch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ The README at the repo root describes the architecture in detail; treat it as th
 
 ```bash
 npm install
-cp .env.example .env.local       # then fill in PI key + secret
+cp .env.example .env.local       # then fill in PI key + secret + Breez key
 npm run dev                       # next dev
 npm run build                     # next build
 npm run start                     # next start (prod)
@@ -25,25 +25,30 @@ There is **no test runner, no typecheck script, and no formatter configured.** `
 
 Path alias: `@/*` maps to the repo root (`tsconfig.json` `baseUrl: "."`). Imports look like `@/lib/types`, `@/components/player`.
 
+`.env.local` keys: `PODCAST_INDEX_KEY` / `PODCAST_INDEX_SECRET` (server-only, used by `lib/pi.ts`) and `NEXT_PUBLIC_BREEZ_API_KEY` (browser-readable; the Spark SDK initializes in the client because it's a self-custodial wallet — the key gates SDK usage, not user funds). `APP_NAME` is optional, defaults to `boostmebitch`.
+
 ## Server vs client boundary (don't cross it)
 
 The Podcast Index credentials (`PODCAST_INDEX_KEY` / `PODCAST_INDEX_SECRET`) must never reach the browser. Enforced by file conventions, not bundler config:
 
-- **Server-only:** `lib/pi.ts` (uses `node:crypto`, reads `process.env`, hits Podcast Index). Imported only by `app/api/search/route.ts` and `app/api/feed/route.ts`. Never import it from anything in `components/` or from `app/page.tsx`.
-- **Browser-only:** `lib/store.ts` (Zustand, `'use client'`), `lib/v4v/nwc.ts` / `webln.ts` / `lnaddr.ts`, `lib/nostr/`, `lib/storage.ts` — they all touch `window.*` or `localStorage`. SSR guards exist (`typeof window === 'undefined'`) but assume client context.
+- **Server-only:** `lib/pi.ts` (uses `node:crypto`, reads `process.env`, hits Podcast Index) and `lib/rss.ts` (raw RSS parser used by the dev feed loader). Imported only by route handlers under `app/api/*`. Never import either from `components/` or from `app/page.tsx`.
+- **Browser-only:** `lib/store.ts` (Zustand, `'use client'`), `lib/v4v/nwc.ts` / `webln.ts` / `lnaddr.ts` / `spark.ts`, `lib/nostr/`, `lib/storage.ts`, `lib/podcast-meta.ts` — they all touch `window.*`, `localStorage`, `sessionStorage`, IndexedDB (Breez SDK), or load WASM. SSR guards exist (`typeof window === 'undefined'`) but assume client context.
 - **Isomorphic:** `lib/types.ts` (pure types), `lib/v4v/boost.ts` (orchestration logic; pulled in by client code).
 
 Components fetch via the local API routes (`fetch('/api/feed?id=…')`) — they never call Podcast Index directly.
 
 ## Nostr identity enrichment
 
-`loginWithExtension()` only returns `{ pubkey, npub }` from NIP-07. After login, `components/nostr-auth.tsx:loadProfile` runs in the background and merges three more pieces onto the identity:
+`loginWithExtension()` only returns `{ pubkey, npub }` from NIP-07. After login (or after the fast-path identity hydration described below), `components/nostr-auth.tsx:loadProfile` runs in the background and merges four more pieces onto/around the identity:
 
 - **Profile metadata (kind:0):** `name`, `display_name`, `picture`, `nip05`, `about` — used to render the avatar + display name in the header. Also auto-fills the boost modal's "From" field.
 - **NIP-65 relay list (kind:10002):** `writeRelays` is the union of unmarked entries and entries marked `write`. Used as the publish target for boost notes and favorites events when present.
 - **NIP-51 favorites (kind:30003 with `d:boostmebitch:favorites`):** the user's saved-podcast set. See "Favorites" below.
+- **Spark wallet backup (kind:30078 with `d:boostmebitch:wallet:spark`):** NIP-44 v2 encrypted-to-self mnemonic. Best-effort silent restore: if found, `sparkInitFromMnemonic` runs in the background and the account-menu's Spark section flips to "wallet ready" without user action. Failures (no NIP-44 in signer, no backup yet, decrypt error) are swallowed — user can hit "Create new" or "Restore from Nostr" manually.
 
-All three queries run against `DEFAULT_RELAYS`. If a user has none of those events on those relays, we fall back to the npub-only header, default publish set, and empty favorites respectively. We do NOT fetch contacts (kind:3), DMs, reactions, or anything else — the only NIP-07 permissions ever requested are `getPublicKey` (login) and `signEvent` (each boost or favorites mutation).
+All queries run against `DEFAULT_RELAYS`. If a user has none of those events on those relays, we fall back to the npub-only header, default publish set, empty favorites, and empty wallet respectively. NIP-07 permissions ever requested: `getPublicKey` (login), `signEvent` (each boost / favorites / wallet mutation), and `nip44.encrypt`/`nip44.decrypt` (wallet backup only). We do NOT fetch contacts (kind:3), DMs, reactions, or anything else.
+
+**Fast-path identity hydration:** on page load, `nostr-auth.tsx` decodes the cached `bmb:npub` synchronously via `nip19.decode` and sets a bare `{ pubkey, npub }` identity *immediately* — the avatar shows up in the header within one frame. The signer (`window.nostr.getPublicKey`) is only called lazily, when the user actually needs to sign something. Profile / relay-list / favorites / wallet enrich asynchronously after that.
 
 `resolvePublishRelays(identity)` in `lib/nostr/` is the single source of truth for "which relays do we publish to": localStorage `bmb:relays` override → identity NIP-65 write relays → `DEFAULT_RELAYS`. Capped at 20 to keep publish latency bounded.
 
@@ -64,7 +69,35 @@ Hydration on login (in `loadProfile`):
 
 Sign-out clears the in-memory favorites; the per-npub localStorage cache is left in place so re-signing in is fast.
 
+**UUID filter at parse:** `lib/nostr/favorites.ts` enforces a UUID shape on every `i: podcast:guid:<value>` tag in the relay event. Older versions of this app (and some other clients reusing the d-tag) wrote feed IDs and arbitrary strings into the i-tag. Those are returned as `droppedGuids` and never sent to PI. When the count is non-zero, `nostr-auth.tsx` registers `window.bmbCleanFavorites()` so the user can republish a cleaned event from devtools.
+
 What this code deliberately doesn't do: episode-level favorites, multiple lists/categories, or any "share this list" UI. The kind:30003 is publicly readable to anyone with the user's pubkey + relay set.
+
+## Wallets — account menu (top right)
+
+All wallet config lives in the avatar dropdown rendered by `components/nostr-auth.tsx:AccountMenu`. The boost modal's rail picker (`components/boost-modal/rail-picker.tsx`) is a pure tab selector — no setup affordances. The hint line at the bottom of the picker points users back to the menu when no rail is configured.
+
+Three wallet sub-cards, each its own component:
+
+- `components/nwc-wallet.tsx` — paste a `nostr+walletconnect://` URI / disconnect. Persists to `bmb:nwc_uri` via `lib/v4v/nwc.ts`.
+- `components/spark-wallet.tsx` — Create new (BIP-39 → mnemonic display → NIP-44 encrypt-to-self → kind:30078 publish → SDK init), Restore from Nostr (fetch + decrypt + init), Disconnect. Once initialized, `<ReadyPanel>` shows the live balance + a deposit-invoice generator (BOLT11 + QR + copy + auto-dismiss when the payment lands).
+- `components/webln-wallet.tsx` — auto-detects `window.webln`. "Enable for this site" pre-authorizes so the first boost doesn't pause for a permission prompt.
+
+Wallet state changes (Spark init / disconnect / auto-restore landing) propagate to the UI via the `subscribeSpark()` listener pattern in `lib/v4v/spark.ts`. The menu re-reads `hasSpark()` on every notification — works whether the menu is closed or already open when state flips.
+
+## Spark rail (Breez SDK)
+
+`lib/v4v/spark.ts` wraps `@breeztech/breez-sdk-spark`. The package ships as a WASM module with multiple entry points; we use the default browser export and the SDK's default export (`initBreezSDK`) as a one-shot WASM loader. Init is two-stage and the WASM only lands in the bundle the first time a user opens a Spark wallet (dynamic import inside `sparkInitFromMnemonic`).
+
+Load-bearing rules:
+
+1. **BOLT11 only.** Spark cannot keysend. `lib/v4v/boost.ts` rejects every `node`-type recipient on the Spark rail per-leg with a clear error, never silently. lnaddress recipients work because `payOne` fetches a BOLT11 from the LNURL-pay callback first.
+2. **Network is `mainnet` or `regtest` — there is no public testnet for Spark.** First end-to-end boost moves real sats. Use `network: 'regtest'` against a local node for development; the type union enforces this.
+3. **`storageDir` is keyed on `(ownerPubkey[:8], sha256(mnemonic)[:8])`.** Two wallets for the same npub get different SDK directories — `walletStorageDir()` does the hashing. Keying on pubkey alone collides if a user disconnects + creates fresh; the SDK either rejects re-init or corrupts existing wallet state.
+4. **Two-step send.** `sparkPayInvoice(invoice)` runs `sdk.prepareSendPayment({ paymentRequest })` then `sdk.sendPayment({ prepareResponse })`. Preimage extracted from `payment.preimage` or `payment.details.htlcDetails.preimage` depending on the payment shape.
+5. **Events drive the balance, not polling.** `sparkInitFromMnemonic` exposes `subscribeSparkEvents()` wrapping the SDK's `addEventListener`. `paymentSucceeded`, `claimedDeposits`, `newDeposits`, `synced` trigger an immediate `sparkGetInfo()` refresh in `<ReadyPanel>`. `paymentSucceeded`/`claimedDeposits`/`newDeposits` also auto-dismiss any outstanding deposit invoice.
+
+The mnemonic is published encrypt-to-self as kind:30078 with `d:boostmebitch:wallet:spark` — see `lib/nostr/wallet-backup.ts`. Anyone with the user's nsec can decrypt; the Nostr backup is convenience, not the only copy. The seed-display step in `<SparkWallet>` is the user's chance to write it down. Re-create flow checks for an existing backup and confirms before overwriting (kind:30078 is a NIP-33 replaceable event — newer wins, prior backup is gone forever from relays).
 
 ## Show-level boost
 
@@ -82,7 +115,7 @@ The "⚡ BOOST" button at the top-right of `EpisodeList`'s header opens the moda
 `components/boost-modal/index.tsx` orchestrates the user flow (state + `go()`), with render-only slice components in the same folder; `lib/v4v/boost.ts` is the engine. A few rules are load-bearing:
 
 1. **Lightning first, then Nostr.** `publishBoostNote` only fires after `sendBoost` returns *and* at least one recipient succeeded (`collected.some(r => r.ok)`). This prevents false "I boosted" notes when payments all fail. Don't reorder.
-2. **Rail priority is NWC over WebLN.** `pickRail()` in `lib/v4v/boost.ts` returns `'nwc'` if a URI is saved, else `'webln'`, else `null`. The modal lets the user override but defaults to this.
+2. **Rail priority is NWC > Spark > WebLN.** `pickRail()` in `lib/v4v/boost.ts` returns `'nwc'` if a URI is saved, else `'spark'` if a Spark wallet is initialized, else `'webln'` if a browser provider is detected, else `null`. The modal lets the user override but defaults to this. Spark only handles BOLT11 / lnaddress legs — see "Spark rail" above.
 3. **Episode value-block fallback happens server-side.** `app/api/feed/route.ts` does `e.value ?? podcast.value` before returning. Components assume `episode.value` is populated when the channel has one — don't re-implement the fallback in the modal.
 4. **Splits use weights, not percentages.** `splitSats()` floors per-recipient, then dumps the remainder onto the first non-fee recipient. `ValueRecipient.split` is a weight; total weight is the denominator.
 5. **TLV records:** boostagram JSON goes in record `7629169` (Podcasting 2.0 standard) — that's the only TLV we add for boost metadata. The `sender_id` field already lives inside the JSON; we deliberately do **not** also emit a separate `696969` sender record because that key collides with shared-node sub-account routing (e.g. getalby.com uses `customKey=696969 customValue=<sub-account>`). Per-recipient `customKey`/`customValue` from the value block IS attached to the keysend so payments to shared nodes route to the right sub-account. Keep the JSON shape compatible with Helipad / Fountain / Castamatic ingestion.
@@ -118,7 +151,28 @@ Same `signAndPublish` helper handles both kind:1 boost notes and kind:30003 favo
 
 ## v4v-toolkit swap-out boundary
 
-`lib/v4v/*` and `lib/nostr/` are intentionally the only files that talk to wallets / signers. Components import only from these three entry points: `lib/v4v/boost.ts` (orchestrator), `lib/v4v/nwc.ts` (URI persistence helpers), `lib/nostr/` barrel (auth + publish). When swapping in `v4v-toolkit`, replace internals here without touching `components/` or `app/`.
+`lib/v4v/*` and `lib/nostr/` are intentionally the only files that talk to wallets / signers. Components import only from these entry points: `lib/v4v/boost.ts` (orchestrator), `lib/v4v/nwc.ts` (URI persistence), `lib/v4v/spark.ts` (Spark wallet surface), `lib/nostr/` barrel (auth + publish + wallet backup). When swapping in `v4v-toolkit`, replace internals here without touching `components/` or `app/`.
+
+## /api/by-guid resilience and PI breaker
+
+`/api/by-guid` 5xxs when the Podcast Index keys are missing or PI is down. Without protection, a returning user with a 100-guid favorites set hammers the broken endpoint on every reload — and StrictMode + Fast Refresh can amplify that into thousands of dev requests.
+
+`lib/podcast-meta.ts` is the single resolver everyone uses (favorites hydrator, global Nostr feed, future surfaces). Four guards stacked:
+
+1. In-memory `Map<guid, Podcast | null>` — fastest path within a page session, also caches misses so the same guid is only attempted once per load.
+2. `storage.podcastMeta` (localStorage, 7-day TTL) — survives reloads.
+3. **Circuit breaker.** First 5xx response trips `sessionStorage['bmb:pi:dead'] = '1'`. Persists across reloads in the same tab (a hard refresh starts a new session). `piMaybeUp()` lets callers gate parallel batches before firing fetches.
+4. Network.
+
+Callers that fan out (favorites hydrator, global Nostr feed) use a **probe-first-then-batch** pattern: await one `resolvePodcastByGuid` first, check `piMaybeUp()`, only then fire `Promise.all` over the rest. One wasted fetch per page load instead of N.
+
+The global feed's resolver runs in a `useEffect` that depends only on `notes` (not on the local `podcasts` state). Tracking which guids have been attempted lives in a `useRef<Set<string>>` so `setPodcasts` doesn't re-fire the effect — that pattern caused a fetch storm where cancelled-but-already-in-flight requests kept pinning the dev server.
+
+## Dev RSS feed loader
+
+`lib/rss.ts` + `app/api/feed-by-url/route.ts` parse a raw Podcasting 2.0 RSS feed into the same `{ podcast, episodes }` shape that `/api/feed` returns from PI. The empty-state on `app/page.tsx` has a "Load test feed (Bowl After Bowl)" button that hits the URL endpoint, bypassing PI entirely. `EpisodeList` accepts an optional `feedUrl` prop that swaps to the URL-based endpoint when set. Synthetic negative `feedId` distinguishes dev-loaded feeds from real PI results in logs.
+
+This was added so the app is exercisable locally without `PODCAST_INDEX_KEY` configured.
 
 ## Background art and the canvas-bg gotcha
 
@@ -135,6 +189,14 @@ Everything else lives in `localStorage` on the device and is never sent server-s
 - `bmb:sender_name` — last "From" name typed into the boost modal (`storage.senderName`).
 - `bmb:npub` — sentinel for silent re-login on page load (`storage.npub`).
 - `bmb:favorites:<npub>` / `bmb:favorites:guest` — per-identity favorites cache (`storage.favorites.get(npub) / .set(npub, …)`).
+- `bmb:pmeta:<guid>` — `/api/by-guid` resolution cache, 7-day TTL (`storage.podcastMeta`). Used by the favorites hydrator, global Nostr feed, and any future surface that needs a `Podcast` from a guid.
+- `bmb:feed:<key>` — last `DiscoveredNote[]` per feed surface, 5-minute TTL (`storage.feedNotes`). Drives the global feed's stale-while-revalidate paint.
+
+`sessionStorage` (per-tab, not per-device):
+
+- `bmb:pi:dead` — circuit-breaker sentinel set when `/api/by-guid` returns 5xx. Persists across reloads in the same tab, cleared on hard refresh into a new tab.
+
+External persistence: the **Spark wallet's mnemonic** lives encrypted on Nostr relays as kind:30078 (publicly readable, private to the user's nsec). The Breez SDK's own wallet state (UTXOs, payment history, etc.) lives in IndexedDB managed by the SDK at `bmb-spark-<pubkey:8>-<sha256(mnemonic):8>`.
 
 If you add another persisted field, add a typed accessor to `lib/storage.ts` and follow the `bmb:*` prefix.
 

--- a/app/api/feed-by-url/route.ts
+++ b/app/api/feed-by-url/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { fetchAndParseRss } from '@/lib/rss';
+import { getErrorMessage } from '@/lib/util';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const url = searchParams.get('url');
+  if (!url) return NextResponse.json({ error: 'missing url' }, { status: 400 });
+  if (!/^https?:\/\//i.test(url)) {
+    return NextResponse.json({ error: 'url must be http(s)' }, { status: 400 });
+  }
+  try {
+    const { podcast, episodes } = await fetchAndParseRss(url);
+    return NextResponse.json({ podcast, episodes });
+  } catch (e) {
+    return NextResponse.json({ error: getErrorMessage(e, 'rss fetch failed') }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,16 +9,22 @@ import { useApp } from '@/lib/store';
 
 import type { Podcast } from '@/lib/types';
 
+// Hardcoded test feed for local dev when PODCAST_INDEX_KEY isn't set.
+// Bypasses search and loads via /api/feed-by-url.
+const DEV_FEED_URL = 'https://feed.bowlafterbowl.com/feed.xml';
+
 export default function Home() {
   const [feeds, setFeeds] = useState<Podcast[]>([]);
   const [selected, setSelected] = useState<Podcast | null>(null);
+  const [devFeedUrl, setDevFeedUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState('');
   const favorites = useApp((s) => s.favorites);
   const hasFavorites = Object.keys(favorites).length > 0;
 
   const showFavoritesPanel = !query && hasFavorites;
-  const showLeftRightLayout = loading || feeds.length > 0 || selected || showFavoritesPanel;
+  const showLeftRightLayout = loading || feeds.length > 0 || selected || devFeedUrl || showFavoritesPanel;
+  const inDetailView = !!(selected || devFeedUrl);
 
   return (
     <main className="min-h-screen pb-32">
@@ -54,7 +60,7 @@ export default function Home() {
 
       {/* Results grid */}
       <section className="max-w-7xl mx-auto px-4 pt-2">
-        {selected ? (
+        {inDetailView ? (
           // Detail "page" — once a podcast is picked, the search/favorites
           // aside hides so the episode list + per-podcast Nostr feed get the
           // full viewport. The back button returns the user to whatever
@@ -62,14 +68,14 @@ export default function Home() {
           // in state).
           <div>
             <button
-              onClick={() => setSelected(null)}
+              onClick={() => { setSelected(null); setDevFeedUrl(null); }}
               className="btn-ghost text-xs mb-3"
               aria-label="Back"
             >
               ← back to results
             </button>
             <section className="card p-4 min-h-[40vh]">
-              <EpisodeList feedId={selected.id} />
+              <EpisodeList feedId={selected?.id ?? null} feedUrl={devFeedUrl} />
             </section>
           </div>
         ) : showLeftRightLayout ? (
@@ -102,11 +108,11 @@ export default function Home() {
             </section>
           </div>
         ) : (
-          <EmptyState />
+          <EmptyState onLoadDevFeed={() => setDevFeedUrl(DEV_FEED_URL)} />
         )}
       </section>
 
-      {!selected && (
+      {!inDetailView && (
         <section className="max-w-7xl mx-auto px-4 pt-12">
           <GlobalNostrFeed />
         </section>
@@ -117,20 +123,30 @@ export default function Home() {
   );
 }
 
-function EmptyState() {
+function EmptyState({ onLoadDevFeed }: { onLoadDevFeed: () => void }) {
   return (
-    <div className="grid sm:grid-cols-3 gap-4 mt-6">
-      {[
-        { n: '01', t: 'Search', d: 'Powered by the Podcast Index. V4V-enabled feeds get a yellow stamp.' },
-        { n: '02', t: 'Listen', d: 'Full-fidelity playback from the original enclosure URL.' },
-        { n: '03', t: 'Boost', d: 'Splits go out via NWC or WebLN. Boostagrams ride along in TLV 7629169.' },
-      ].map((step) => (
-        <article key={step.n} className="card p-4">
-          <div className="font-mono text-bolt text-sm">{step.n}</div>
-          <div className="font-display text-xl mt-1">{step.t}</div>
-          <p className="text-xs text-muted mt-1.5 leading-relaxed">{step.d}</p>
-        </article>
-      ))}
-    </div>
+    <>
+      <div className="grid sm:grid-cols-3 gap-4 mt-6">
+        {[
+          { n: '01', t: 'Search', d: 'Powered by the Podcast Index. V4V-enabled feeds get a yellow stamp.' },
+          { n: '02', t: 'Listen', d: 'Full-fidelity playback from the original enclosure URL.' },
+          { n: '03', t: 'Boost', d: 'Splits go out via NWC or WebLN. Boostagrams ride along in TLV 7629169.' },
+        ].map((step) => (
+          <article key={step.n} className="card p-4">
+            <div className="font-mono text-bolt text-sm">{step.n}</div>
+            <div className="font-display text-xl mt-1">{step.t}</div>
+            <p className="text-xs text-muted mt-1.5 leading-relaxed">{step.d}</p>
+          </article>
+        ))}
+      </div>
+      <div className="mt-6 text-center">
+        <button onClick={onLoadDevFeed} className="btn-ghost text-xs">
+          Load test feed (Bowl After Bowl)
+        </button>
+        <div className="text-[10px] text-muted mt-1">
+          dev shortcut — bypasses Podcast Index, loads RSS directly
+        </div>
+      </div>
+    </>
   );
 }

--- a/components/boost-modal/rail-picker.tsx
+++ b/components/boost-modal/rail-picker.tsx
@@ -1,8 +1,8 @@
 'use client';
-import { useState } from 'react';
-import { hasNwc, saveNwcUri, clearNwcUri } from '@/lib/v4v/nwc';
+import { hasNwc } from '@/lib/v4v/nwc';
 import { hasWebln } from '@/lib/v4v/webln';
-import { pickRail, type Rail } from '@/lib/v4v/boost';
+import { hasSpark } from '@/lib/v4v/spark';
+import { type Rail } from '@/lib/v4v/boost';
 
 interface Props {
   rail: Rail | null;
@@ -10,54 +10,37 @@ interface Props {
 }
 
 export function RailPicker({ rail, onRailChange }: Props) {
-  const [nwcUri, setNwcUri] = useState('');
-
-  function connectNwc() {
-    const uri = nwcUri.trim();
-    if (!uri.startsWith('nostr+walletconnect://')) {
-      alert('Paste a nostr+walletconnect:// URI');
-      return;
-    }
-    saveNwcUri(uri);
-    onRailChange('nwc');
-    setNwcUri('');
-  }
+  const nwcReady = hasNwc();
+  const sparkReady = hasSpark();
+  const weblnReady = hasWebln();
+  const noneReady = !nwcReady && !sparkReady && !weblnReady;
 
   return (
     <div>
       <label className="text-[11px] uppercase tracking-widest text-muted">Pay with</label>
       <div className="flex gap-2 mt-1.5 flex-wrap">
         <button
-          onClick={() => hasNwc() && onRailChange('nwc')}
-          disabled={!hasNwc()}
+          onClick={() => nwcReady && onRailChange('nwc')}
+          disabled={!nwcReady}
           className={`btn-ghost ${rail === 'nwc' ? '!border-bolt !text-bolt' : ''} disabled:opacity-30`}
-        >NWC {hasNwc() ? '✓' : ''}</button>
+        >NWC {nwcReady ? '✓' : ''}</button>
         <button
-          onClick={() => hasWebln() && onRailChange('webln')}
-          disabled={!hasWebln()}
+          onClick={() => sparkReady && onRailChange('spark')}
+          disabled={!sparkReady}
+          className={`btn-ghost ${rail === 'spark' ? '!border-bolt !text-bolt' : ''} disabled:opacity-30`}
+        >Spark {sparkReady ? '✓' : ''}</button>
+        <button
+          onClick={() => weblnReady && onRailChange('webln')}
+          disabled={!weblnReady}
           className={`btn-ghost ${rail === 'webln' ? '!border-bolt !text-bolt' : ''} disabled:opacity-30`}
-        >WebLN {hasWebln() ? '✓' : ''}</button>
+        >WebLN {weblnReady ? '✓' : ''}</button>
       </div>
 
-      {!hasNwc() && (
-        <div className="mt-3 flex gap-2">
-          <input
-            className="input"
-            placeholder="nostr+walletconnect://… (paste from Alby Hub)"
-            value={nwcUri}
-            onChange={(e) => setNwcUri(e.target.value)}
-          />
-          <button onClick={connectNwc} className="btn-ghost">Save</button>
-        </div>
-      )}
-      {hasNwc() && rail === 'nwc' && (
-        <button
-          onClick={() => { clearNwcUri(); onRailChange(pickRail()); }}
-          className="text-[11px] text-muted hover:text-nostr mt-2"
-        >
-          disconnect NWC
-        </button>
-      )}
+      <div className="text-[10px] text-muted mt-1.5">
+        {noneReady
+          ? 'No wallet connected — set one up in the account menu (top right).'
+          : 'Manage wallets in the account menu (top right).'}
+      </div>
     </div>
   );
 }

--- a/components/global-nostr-feed.tsx
+++ b/components/global-nostr-feed.tsx
@@ -1,45 +1,20 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   fetchAllPodcastNotes,
   useNostrFeed,
   type DiscoveredNote,
 } from '@/lib/nostr';
-import { storage } from '@/lib/storage';
+import { piMaybeUp, resolvePodcastByGuid } from '@/lib/podcast-meta';
 import type { Podcast } from '@/lib/types';
 import { FeedSection } from './feed-section';
 import { NoteCard } from './nostr-note-card';
 
-// In-memory mirror of storage.podcastMeta — avoids re-parsing localStorage on
-// every NoteCard render within the same page session.
-const podcastMem = new Map<string, Podcast | null>();
-
-async function resolvePodcast(guid: string): Promise<Podcast | null> {
-  if (podcastMem.has(guid)) return podcastMem.get(guid) ?? null;
-  const cached = storage.podcastMeta.get(guid);
-  if (cached) {
-    podcastMem.set(guid, cached);
-    return cached;
-  }
-  try {
-    const r = await fetch(`/api/by-guid?guid=${encodeURIComponent(guid)}`);
-    if (!r.ok) {
-      podcastMem.set(guid, null);
-      return null;
-    }
-    const { podcast } = (await r.json()) as { podcast: Podcast };
-    if (podcast) {
-      podcastMem.set(guid, podcast);
-      storage.podcastMeta.set(guid, podcast);
-      return podcast;
-    }
-    podcastMem.set(guid, null);
-    return null;
-  } catch {
-    podcastMem.set(guid, null);
-    return null;
-  }
-}
+// UUID-shaped podcast:guid filter. Some clients post boost notes with
+// non-UUID values in the i-tag (feed IDs, episode strings); those will
+// never resolve via PI's /podcasts/byguid endpoint, so we drop them at
+// the source instead of round-tripping a 404.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Global stream of every kind:1 note tagged with NIP-73 podcast identifiers,
@@ -53,21 +28,40 @@ export function GlobalNostrFeed() {
     fetcher: fetchAllPodcastNotes,
   });
   const [podcasts, setPodcasts] = useState<Record<string, Podcast | null>>({});
+  // Tracks guids we've already kicked off a resolve for. Lives in a ref
+  // (not state) so updating it doesn't re-fire the effect — putting it in
+  // deps with the effect's own setPodcasts created a fetch storm where
+  // cancelled-but-already-in-flight requests kept hitting the network on
+  // every render cycle.
+  const attempted = useRef<Set<string>>(new Set());
 
-  // Resolve podcast metadata for every unique guid that appears in `notes` —
-  // covers both the SWR cache paint and every refresh.
+  // Resolve podcast metadata for every unique guid in `notes`. Probe-first
+  // pattern: do the first fetch sequentially so the breaker can trip before
+  // the rest of the batch fires in parallel.
   useEffect(() => {
     if (!notes) return;
     const guids = Array.from(
       new Set(notes.map((n) => n.podcastGuid).filter((g): g is string => !!g)),
-    );
-    for (const guid of guids) {
-      if (guid in podcasts) continue;
-      resolvePodcast(guid).then((p) => {
-        setPodcasts((prev) => ({ ...prev, [guid]: p }));
+    ).filter((g) => UUID_RE.test(g) && !attempted.current.has(g));
+    if (guids.length === 0) return;
+    for (const g of guids) attempted.current.add(g);
+    let cancelled = false;
+    (async () => {
+      const [first, ...rest] = guids;
+      const firstPodcast = await resolvePodcastByGuid(first);
+      if (cancelled) return;
+      setPodcasts((prev) => ({ ...prev, [first]: firstPodcast }));
+      if (!piMaybeUp()) return;
+      const restPodcasts = await Promise.all(rest.map(resolvePodcastByGuid));
+      if (cancelled) return;
+      setPodcasts((prev) => {
+        const next = { ...prev };
+        rest.forEach((g, i) => { next[g] = restPodcasts[i]; });
+        return next;
       });
-    }
-  }, [notes, podcasts]);
+    })();
+    return () => { cancelled = true; };
+  }, [notes]);
 
   return (
     <FeedSection

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -215,7 +215,7 @@ function ValueBlockDetails({ value }: { value: ValueBlock }) {
   );
 }
 
-export function EpisodeList({ feedId }: { feedId: number | null }) {
+export function EpisodeList({ feedId, feedUrl }: { feedId: number | null; feedUrl?: string | null }) {
   const [data, setData] = useState<{ podcast: Podcast | null; episodes: Episode[] }>({
     podcast: null, episodes: [],
   });
@@ -228,21 +228,21 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
 
   useEffect(() => {
     setValueOpen(false);
-    if (!feedId) { setData({ podcast: null, episodes: [] }); return; }
+    if (!feedId && !feedUrl) { setData({ podcast: null, episodes: [] }); return; }
     setLoading(true);
-    fetch(`/api/feed?id=${feedId}`)
+    const endpoint = feedUrl
+      ? `/api/feed-by-url?url=${encodeURIComponent(feedUrl)}`
+      : `/api/feed?id=${feedId}`;
+    fetch(endpoint)
       .then((r) => r.json())
       .then((d) => setData({ podcast: d.podcast, episodes: d.episodes }))
       .finally(() => setLoading(false));
-    // Below the lg: breakpoint the search aside sits above this panel and
-    // takes most of the viewport, so a tap on a result wouldn't visibly move
-    // anything without this nudge.
     if (typeof window !== 'undefined' && window.innerWidth < 1024) {
       containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
-  }, [feedId]);
+  }, [feedId, feedUrl]);
 
-  if (!feedId) {
+  if (!feedId && !feedUrl) {
     return (
       <div ref={containerRef} className="text-muted text-sm py-12 text-center px-4 border border-dashed border-bone/15">
         select a podcast on the left to see episodes

--- a/components/nostr-auth.tsx
+++ b/components/nostr-auth.tsx
@@ -1,38 +1,48 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { nip19 } from 'nostr-tools';
 import {
   loginWithExtension,
   shortNpub,
   fetchProfile,
   fetchRelayList,
   fetchFavoriteGuids,
+  fetchEncryptedMnemonic,
   resolvePublishRelays,
   schedulePublishFavorites,
   type NostrIdentity,
 } from '@/lib/nostr';
+import { hasSpark, sparkInitFromMnemonic } from '@/lib/v4v/spark';
 import { useApp } from '@/lib/store';
 import { storage } from '@/lib/storage';
 import { getErrorMessage } from '@/lib/util';
+import { piMaybeUp, resolvePodcastByGuid } from '@/lib/podcast-meta';
 import type { FavoritePodcast, Podcast } from '@/lib/types';
+import { SparkWallet } from './spark-wallet';
+import { NwcWallet } from './nwc-wallet';
+import { WeblnWallet } from './webln-wallet';
+
+// Module-level promise cache keyed by pubkey, so the same loadProfile call
+// isn't fired twice when React remounts the component (StrictMode in dev,
+// Fast Refresh on every save).
+const pendingProfileLoad = new Map<string, Promise<void>>();
+
+function favoriteFromPodcast(p: Podcast): FavoritePodcast | null {
+  if (!p?.podcastGuid) return null;
+  return {
+    id: p.id,
+    podcastGuid: p.podcastGuid,
+    title: p.title,
+    author: p.author,
+    image: p.image,
+    url: p.url,
+    addedAt: Date.now(),
+  };
+}
 
 async function resolveGuidToFavorite(guid: string): Promise<FavoritePodcast | null> {
-  try {
-    const r = await fetch(`/api/by-guid?guid=${encodeURIComponent(guid)}`);
-    if (!r.ok) return null;
-    const { podcast } = (await r.json()) as { podcast: Podcast };
-    if (!podcast?.podcastGuid) return null;
-    return {
-      id: podcast.id,
-      podcastGuid: podcast.podcastGuid,
-      title: podcast.title,
-      author: podcast.author,
-      image: podcast.image,
-      url: podcast.url,
-      addedAt: Date.now(),
-    };
-  } catch {
-    return null;
-  }
+  const podcast = await resolvePodcastByGuid(guid);
+  return podcast ? favoriteFromPodcast(podcast) : null;
 }
 
 /**
@@ -59,6 +69,27 @@ async function hydrateFavorites(identity: NostrIdentity): Promise<void> {
     return;
   }
 
+  if (favEvent.droppedGuids.length > 0) {
+    // Old buggy versions of this app (or another client reusing the d-tag)
+    // wrote non-UUID values into the favorites event. They'd 404 against
+    // PI, so we silently filter them. Log once so the user knows, and
+    // expose a one-shot cleanup hook for permanent removal.
+    if (typeof window !== 'undefined') {
+      (window as any).bmbCleanFavorites = () => {
+        const valid = Object.keys(useApp.getState().favorites);
+        schedulePublishFavorites(() => valid, resolvePublishRelays(identity));
+        return `republishing kind:30003 with ${valid.length} valid guids (debounced ~1.5s)`;
+      };
+    }
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[favorites] dropped ${favEvent.droppedGuids.length} non-UUID entries from your kind:30003 event:`,
+      favEvent.droppedGuids,
+      '\nTo permanently remove them from relays, run:',
+      '  bmbCleanFavorites()',
+    );
+  }
+
   // localStorage doesn't carry an event timestamp; the most recent `addedAt`
   // in the cache is a reasonable proxy.
   const localNewest = cachedGuids.reduce(
@@ -78,9 +109,15 @@ async function hydrateFavorites(identity: NostrIdentity): Promise<void> {
   setFavorites(next);
 
   if (unresolved.length > 0) {
-    const resolved = await Promise.all(unresolved.map(resolveGuidToFavorite));
+    // Probe sequentially with the first guid. If PI is dead (or already
+    // tripped earlier this session), the breaker fires and we skip the
+    // rest of the batch instead of opening 99 sockets in parallel that
+    // are all going to 500.
+    const firstFav = await resolveGuidToFavorite(unresolved[0]);
+    const remaining = piMaybeUp() ? unresolved.slice(1) : [];
+    const restFavs = await Promise.all(remaining.map(resolveGuidToFavorite));
     const merged = { ...useApp.getState().favorites };
-    for (const fav of resolved) {
+    for (const fav of [firstFav, ...restFavs]) {
       if (fav) merged[fav.podcastGuid] = fav;
     }
     setFavorites(merged);
@@ -102,6 +139,17 @@ export function NostrAuth() {
   const [err, setErr] = useState<string | null>(null);
 
   async function loadProfile(id: NostrIdentity) {
+    // Dedupe across remounts (StrictMode runs effects twice in dev; Fast
+    // Refresh re-runs them on every save). Without this, a returning user
+    // re-fetches profile/relay-list/favorites/wallet every keystroke.
+    const existing = pendingProfileLoad.get(id.pubkey);
+    if (existing) return existing;
+    const p = doLoadProfile(id);
+    pendingProfileLoad.set(id.pubkey, p);
+    return p;
+  }
+
+  async function doLoadProfile(id: NostrIdentity) {
     try {
       const [profile, relayList] = await Promise.all([
         fetchProfile(id.pubkey),
@@ -112,17 +160,38 @@ export function NostrAuth() {
       if (relayList?.write?.length) enriched.writeRelays = relayList.write;
       setIdentity(enriched);
       await hydrateFavorites(enriched);
+      // Best-effort Spark wallet restore. Silent on missing NIP-44 / no
+      // backup yet — user can hit "Create wallet" manually in the account
+      // menu (top-right).
+      if (!hasSpark()) {
+        fetchEncryptedMnemonic(enriched)
+          .then((mnemonic) => {
+            if (mnemonic) return sparkInitFromMnemonic({ mnemonic, ownerPubkey: enriched.pubkey });
+          })
+          .catch(() => {});
+      }
     } catch { /* ignore — keep bare identity */ }
   }
 
   useEffect(() => {
-    // Auto-sign-in if extension is already present and previously approved
+    // Fast-path: hydrate the header from localStorage so the avatar slot
+    // doesn't read "Sign in with Nostr" while we wait on the signer +
+    // profile/relay-list relays. Decoding npub → hex pubkey is sync and
+    // sufficient for display + read-only relay queries; the actual signer
+    // (window.nostr.signEvent / nip44) is only needed when an action
+    // requires signing, and we lazy-call it then.
+    if (identity || typeof window === 'undefined') return;
     const stored = storage.npub.get();
-    if (stored && !identity && typeof window !== 'undefined' && window.nostr) {
-      loginWithExtension()
-        .then((id) => { setIdentity(id); loadProfile(id); })
-        .catch(() => {});
-    }
+    if (!stored) return;
+    let pubkey: string;
+    try {
+      const decoded = nip19.decode(stored);
+      if (decoded.type !== 'npub') return;
+      pubkey = decoded.data;
+    } catch { return; }
+    const bare: NostrIdentity = { pubkey, npub: stored };
+    setIdentity(bare);
+    loadProfile(bare);
   }, [identity, setIdentity]);
 
   async function signin() {
@@ -144,10 +213,60 @@ export function NostrAuth() {
   }
 
   if (identity) {
-    const name = identity.profile?.display_name || identity.profile?.name;
-    const pic = identity.profile?.picture;
-    return (
-      <button onClick={signout} className="btn-ghost group flex items-center gap-2" title="Sign out">
+    return <AccountMenu identity={identity} onSignOut={signout} />;
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button onClick={signin} disabled={busy} className="btn-ghost">
+        <span className="text-nostr">◆</span>
+        {busy ? 'Connecting…' : 'Sign in with Nostr'}
+      </button>
+      {err && <span className="text-[10px] text-nostr/80 max-w-[260px] text-right">{err}</span>}
+    </div>
+  );
+}
+
+function AccountMenu({
+  identity,
+  onSignOut,
+}: {
+  identity: NostrIdentity;
+  onSignOut: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  // Dismiss on click-outside / Escape so the menu doesn't trap focus.
+  useEffect(() => {
+    if (!open) return;
+    function onMouseDown(e: MouseEvent) {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const name = identity.profile?.display_name || identity.profile?.name;
+  const pic = identity.profile?.picture;
+
+  return (
+    <div ref={wrapperRef} className="relative">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="btn-ghost group flex items-center gap-2"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
         {pic ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img
@@ -162,18 +281,44 @@ export function NostrAuth() {
         <span className="hidden sm:inline truncate max-w-[160px]">
           {name || shortNpub(identity.npub, 6)}
         </span>
-        <span className="opacity-40 group-hover:opacity-100 transition">↗</span>
+        <span className="opacity-40 group-hover:opacity-100 transition text-[10px]">
+          {open ? '▴' : '▾'}
+        </span>
       </button>
-    );
-  }
 
-  return (
-    <div className="flex flex-col items-end gap-1">
-      <button onClick={signin} disabled={busy} className="btn-ghost">
-        <span className="text-nostr">◆</span>
-        {busy ? 'Connecting…' : 'Sign in with Nostr'}
-      </button>
-      {err && <span className="text-[10px] text-nostr/80 max-w-[260px] text-right">{err}</span>}
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-2 w-[min(360px,calc(100vw-2rem))] card bg-ink p-4 z-30 shadow-xl"
+        >
+          <div className="border-b border-bone/15 pb-3 mb-3">
+            <div className="text-sm">{name || 'Anon'}</div>
+            <div className="text-[10px] text-muted truncate">{shortNpub(identity.npub, 8)}</div>
+          </div>
+
+          <div className="text-[11px] uppercase tracking-widest text-muted">
+            Connect wallet
+          </div>
+
+          <div className="mt-2 text-[11px] uppercase tracking-widest text-bone/60">NWC</div>
+          <NwcWallet />
+
+          <div className="mt-4 text-[11px] uppercase tracking-widest text-bone/60">Spark</div>
+          <SparkWallet />
+
+          <div className="mt-4 text-[11px] uppercase tracking-widest text-bone/60">WebLN</div>
+          <WeblnWallet />
+
+          <div className="border-t border-bone/15 mt-4 pt-3">
+            <button
+              onClick={() => { onSignOut(); setOpen(false); }}
+              className="text-[11px] text-muted hover:text-nostr"
+            >
+              sign out
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/nwc-wallet.tsx
+++ b/components/nwc-wallet.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+// NWC connect/disconnect surface for the account menu. Mirrors the
+// SparkWallet shape: paste a nostr+walletconnect:// URI (typically from
+// Alby Hub, getalby.com, or your own node), or disconnect to remove the
+// stored URI from localStorage.
+
+import { useState } from 'react';
+import { hasNwc, saveNwcUri, clearNwcUri, loadNwcUri } from '@/lib/v4v/nwc';
+
+export function NwcWallet() {
+  const [, setTick] = useState(0);
+  const [draft, setDraft] = useState('');
+  const [err, setErr] = useState<string | null>(null);
+
+  function bump() { setTick((t) => t + 1); }
+
+  function connect() {
+    setErr(null);
+    const uri = draft.trim();
+    if (!uri.startsWith('nostr+walletconnect://')) {
+      setErr('URI must start with nostr+walletconnect://');
+      return;
+    }
+    saveNwcUri(uri);
+    setDraft('');
+    bump();
+  }
+
+  function disconnect() {
+    clearNwcUri();
+    bump();
+  }
+
+  if (hasNwc()) {
+    const uri = loadNwcUri() ?? '';
+    // Show only the wallet domain so the secret isn't visible at a glance.
+    let host = '';
+    try { host = new URL(uri.replace('nostr+walletconnect://', 'https://')).host; } catch {}
+    return (
+      <div className="mt-3 text-[11px] text-muted">
+        <div>NWC connected{host ? ` · ${host}` : ''}</div>
+        <button onClick={disconnect} className="text-muted hover:text-nostr mt-1">
+          disconnect NWC
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      <div className="text-[11px] text-muted">
+        Paste a nostr+walletconnect:// URI from Alby Hub, getalby.com, or your own node.
+      </div>
+      <input
+        className="input"
+        placeholder="nostr+walletconnect://…"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') connect(); }}
+      />
+      <div className="flex gap-2">
+        <button onClick={connect} disabled={!draft.trim()} className="btn-ghost disabled:opacity-30">
+          Connect
+        </button>
+      </div>
+      {err && <div className="text-[11px] text-nostr/80">{err}</div>}
+    </div>
+  );
+}

--- a/components/spark-wallet.tsx
+++ b/components/spark-wallet.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-// Spark wallet UI — minimum surface to drive the create-and-back-up and
-// restore-from-Nostr flows. The Breez Spark SDK itself is still stubbed
-// (lib/v4v/spark.ts), so payments will throw "Spark wallet not initialized"
-// until that's wired. This component exercises everything around it:
-// BIP-39 generation, NIP-44 encrypt-to-self, kind:30078 publish, and
-// fetch-on-restore.
+// Spark wallet UI. Drives create-and-back-up + restore-from-Nostr flows
+// (BIP-39 / NIP-44 / kind:30078) and, once the wallet is initialized,
+// surfaces the balance + a deposit-invoice generator for funding.
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { QRCodeSVG } from 'qrcode.react';
 import { useApp } from '@/lib/store';
 import {
   hasSpark,
@@ -15,7 +13,10 @@ import {
   sparkGenerateMnemonic,
   sparkInitFromMnemonic,
   sparkDisconnect,
+  sparkGetInfo,
+  sparkReceiveInvoice,
   subscribeSpark,
+  subscribeSparkEvents,
 } from '@/lib/v4v/spark';
 import {
   fetchEncryptedMnemonic,
@@ -125,14 +126,7 @@ export function SparkWallet({ onReady }: Props) {
   }
 
   if (ready) {
-    return (
-      <div className="mt-3 text-[11px] text-muted">
-        <div>Spark wallet ready{owner ? ` · ${owner.slice(0, 8)}…` : ''}</div>
-        <button onClick={disconnect} className="text-muted hover:text-nostr mt-1">
-          disconnect Spark
-        </button>
-      </div>
-    );
+    return <ReadyPanel owner={owner} onDisconnect={disconnect} />;
   }
 
   if (mode === 'creating' && draftMnemonic) {
@@ -172,6 +166,7 @@ export function SparkWallet({ onReady }: Props) {
       <div className="text-[11px] text-muted">
         Self-custodial wallet. Mnemonic is NIP-44 encrypted to your pubkey and stored on your write relays.
       </div>
+      {/* Idle-state form below; the ready-state panel is rendered above this block. */}
       <div className="flex gap-2 flex-wrap">
         <button
           onClick={startCreate}
@@ -192,6 +187,174 @@ export function SparkWallet({ onReady }: Props) {
         <div className="text-[11px] text-muted">Sign in with Nostr to create or restore.</div>
       )}
       {err && <div className="text-[11px] text-nostr/80">{err}</div>}
+    </div>
+  );
+}
+
+function ReadyPanel({ owner, onDisconnect }: { owner: string | null; onDisconnect: () => void }) {
+  const [balance, setBalance] = useState<number | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [showReceive, setShowReceive] = useState(false);
+  const [amountSats, setAmountSats] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [invoice, setInvoice] = useState<string | null>(null);
+  const [feeSats, setFeeSats] = useState<number | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true); setErr(null);
+    try {
+      const info = await sparkGetInfo();
+      if (info) setBalance(info.balanceSats);
+    } catch (e) {
+      setErr(getErrorMessage(e, 'failed to read balance'));
+    } finally { setRefreshing(false); }
+  }, []);
+
+  // Initial balance fetch when the panel mounts.
+  useEffect(() => { refresh(); }, [refresh]);
+
+  // Real-time SDK events. paymentSucceeded / claimedDeposits / newDeposits
+  // fire when a deposit lands; sync drives a periodic refresh. On a real
+  // deposit landing we also auto-dismiss any outstanding invoice/QR — the
+  // user paid it, the balance jumped, the screen should reflect that.
+  useEffect(() => {
+    let unsub: (() => void) | null = null;
+    let cancelled = false;
+    subscribeSparkEvents((e) => {
+      if (e.type === 'paymentSucceeded'
+        || e.type === 'claimedDeposits'
+        || e.type === 'newDeposits') {
+        refresh();
+        // setState fns are stable; safe to call from this captured closure
+        // without adding them to the effect's deps.
+        setInvoice(null);
+        setFeeSats(null);
+        setShowReceive(false);
+        setAmountSats('');
+      } else if (e.type === 'synced') {
+        refresh();
+      }
+    }).then((fn) => {
+      if (cancelled) fn();
+      else unsub = fn;
+    });
+    return () => {
+      cancelled = true;
+      if (unsub) unsub();
+    };
+  }, [refresh]);
+
+  async function generate() {
+    setGenerating(true); setErr(null); setInvoice(null); setFeeSats(null); setCopied(false);
+    try {
+      const amt = amountSats.trim() ? Math.max(1, Math.floor(Number(amountSats))) : undefined;
+      const { invoice: inv, feeSats: fee } = await sparkReceiveInvoice({ amountSats: amt });
+      setInvoice(inv);
+      setFeeSats(fee);
+    } catch (e) {
+      setErr(getErrorMessage(e, 'failed to generate invoice'));
+    } finally { setGenerating(false); }
+  }
+
+  async function copy() {
+    if (!invoice) return;
+    try { await navigator.clipboard.writeText(invoice); setCopied(true); setTimeout(() => setCopied(false), 1500); }
+    catch { /* ignore */ }
+  }
+
+  function clearInvoice() {
+    setInvoice(null);
+    setFeeSats(null);
+    setAmountSats('');
+    setShowReceive(false);
+  }
+
+  return (
+    <div className="mt-3 space-y-2 text-[11px]">
+      <div className="flex items-baseline gap-3">
+        <span className="text-muted">Spark wallet ready{owner ? ` · ${owner.slice(0, 8)}…` : ''}</span>
+      </div>
+      <div className="flex items-baseline gap-2">
+        <span className="text-bone text-base font-mono">
+          {balance == null ? '—' : balance.toLocaleString()}
+        </span>
+        <span className="text-muted">sats</span>
+        <button
+          onClick={refresh}
+          disabled={refreshing}
+          className="text-muted hover:text-bolt ml-2 disabled:opacity-30"
+          title="Re-read balance from the SDK"
+        >
+          {refreshing ? '…' : '↻'}
+        </button>
+      </div>
+
+      {!showReceive && !invoice && (
+        <div className="flex gap-2">
+          <button onClick={() => setShowReceive(true)} className="btn-ghost">Receive</button>
+          <button onClick={onDisconnect} className="text-muted hover:text-nostr">disconnect</button>
+        </div>
+      )}
+
+      {showReceive && !invoice && (
+        <div className="space-y-2">
+          <div className="text-muted">
+            Pay this invoice from any Lightning wallet to fund your Spark wallet.
+            Leave amount blank for a zero-amount invoice (sender chooses).
+          </div>
+          <div className="flex gap-2">
+            <input
+              className="input"
+              type="number"
+              min={1}
+              placeholder="amount in sats (optional)"
+              value={amountSats}
+              onChange={(e) => setAmountSats(e.target.value)}
+            />
+            <button
+              onClick={generate}
+              disabled={generating}
+              className="btn-bolt disabled:opacity-30"
+            >
+              {generating ? 'Generating…' : 'Generate'}
+            </button>
+          </div>
+          <button onClick={() => setShowReceive(false)} className="text-muted hover:text-nostr">cancel</button>
+        </div>
+      )}
+
+      {invoice && (
+        <div className="space-y-2">
+          <div className="text-muted">
+            Scan with another Lightning wallet, or copy the BOLT11 below.
+            Balance updates the moment Spark claims the deposit.
+            {feeSats != null && feeSats > 0 ? ` Spark settle fee: ${feeSats.toLocaleString()} sats.` : ''}
+          </div>
+          <div className="flex justify-center bg-bone p-3">
+            {/* `bone` background ensures full QR contrast regardless of dark
+                mode; `imageSettings` left unset so no logo overlays the data
+                modules (some wallets choke on heavy logos). */}
+            <QRCodeSVG
+              value={`lightning:${invoice}`}
+              size={200}
+              level="M"
+              fgColor="#0a0a08"
+              bgColor="#f5f1e8"
+            />
+          </div>
+          <code className="block card p-2 text-[10px] leading-snug break-all select-all">
+            {invoice}
+          </code>
+          <div className="flex gap-2">
+            <button onClick={copy} className="btn-ghost">{copied ? 'Copied' : 'Copy'}</button>
+            <button onClick={clearInvoice} className="text-muted hover:text-nostr">done</button>
+          </div>
+        </div>
+      )}
+
+      {err && <div className="text-nostr/80">{err}</div>}
     </div>
   );
 }

--- a/components/spark-wallet.tsx
+++ b/components/spark-wallet.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+// Spark wallet UI — minimum surface to drive the create-and-back-up and
+// restore-from-Nostr flows. The Breez Spark SDK itself is still stubbed
+// (lib/v4v/spark.ts), so payments will throw "Spark wallet not initialized"
+// until that's wired. This component exercises everything around it:
+// BIP-39 generation, NIP-44 encrypt-to-self, kind:30078 publish, and
+// fetch-on-restore.
+
+import { useEffect, useState } from 'react';
+import { useApp } from '@/lib/store';
+import {
+  hasSpark,
+  sparkOwner,
+  sparkGenerateMnemonic,
+  sparkInitFromMnemonic,
+  sparkDisconnect,
+  subscribeSpark,
+} from '@/lib/v4v/spark';
+import {
+  fetchEncryptedMnemonic,
+  publishEncryptedMnemonic,
+} from '@/lib/nostr';
+import { getErrorMessage } from '@/lib/util';
+
+type Mode = 'idle' | 'creating' | 'restoring' | 'busy';
+
+interface Props {
+  onReady?: () => void;
+}
+
+export function SparkWallet({ onReady }: Props) {
+  const identity = useApp((s) => s.identity);
+  const [, setTick] = useState(0);
+  const [mode, setMode] = useState<Mode>('idle');
+  const [draftMnemonic, setDraftMnemonic] = useState<string | null>(null);
+  const [confirmed, setConfirmed] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const ready = hasSpark();
+  const owner = sparkOwner();
+
+  function bump() { setTick((t) => t + 1); }
+
+  // Re-render when an outside actor (e.g. auto-restore in loadProfile) flips
+  // the wallet state after this component has already mounted.
+  useEffect(() => subscribeSpark(bump), []);
+
+  async function startCreate() {
+    setErr(null);
+    if (!identity) { setErr('Sign in with Nostr first — backups need your pubkey.'); return; }
+    setMode('busy');
+    try {
+      // Replaceable kind:30078 with d-tag boostmebitch:wallet:spark — creating
+      // a new wallet would overwrite any existing backup on relays. If there
+      // is one, force the user to acknowledge before destroying it.
+      const existing = await fetchEncryptedMnemonic(identity).catch(() => null);
+      if (existing) {
+        const ok = window.confirm(
+          'A Spark wallet backup already exists on your relays.\n\n' +
+          'Creating a new wallet will OVERWRITE that backup. The old wallet ' +
+          'will be unrecoverable unless you wrote its seed phrase down.\n\n' +
+          'Continue and overwrite?'
+        );
+        if (!ok) { setMode('idle'); return; }
+      }
+      const m = await sparkGenerateMnemonic();
+      setDraftMnemonic(m);
+      setConfirmed(false);
+      setMode('creating');
+    } catch (e) {
+      setErr(getErrorMessage(e, 'failed to generate mnemonic'));
+      setMode('idle');
+    }
+  }
+
+  async function confirmCreate() {
+    if (!identity || !draftMnemonic) return;
+    setMode('busy'); setErr(null);
+    try {
+      await publishEncryptedMnemonic(identity, draftMnemonic);
+      await sparkInitFromMnemonic({ mnemonic: draftMnemonic, ownerPubkey: identity.pubkey });
+      setDraftMnemonic(null);
+      setConfirmed(false);
+      setMode('idle');
+      bump();
+      onReady?.();
+    } catch (e) {
+      setErr(getErrorMessage(e, 'failed to back up mnemonic'));
+      setMode('creating');
+    }
+  }
+
+  function cancelCreate() {
+    setDraftMnemonic(null);
+    setConfirmed(false);
+    setMode('idle');
+    setErr(null);
+  }
+
+  async function restore() {
+    setErr(null);
+    if (!identity) { setErr('Sign in with Nostr first — restore reads from your relays.'); return; }
+    setMode('restoring');
+    try {
+      const m = await fetchEncryptedMnemonic(identity);
+      if (!m) {
+        setErr('No backup found on your write relays.');
+        setMode('idle');
+        return;
+      }
+      await sparkInitFromMnemonic({ mnemonic: m, ownerPubkey: identity.pubkey });
+      setMode('idle');
+      bump();
+      onReady?.();
+    } catch (e) {
+      setErr(getErrorMessage(e, 'failed to restore wallet'));
+      setMode('idle');
+    }
+  }
+
+  async function disconnect() {
+    await sparkDisconnect();
+    bump();
+  }
+
+  if (ready) {
+    return (
+      <div className="mt-3 text-[11px] text-muted">
+        <div>Spark wallet ready{owner ? ` · ${owner.slice(0, 8)}…` : ''}</div>
+        <button onClick={disconnect} className="text-muted hover:text-nostr mt-1">
+          disconnect Spark
+        </button>
+      </div>
+    );
+  }
+
+  if (mode === 'creating' && draftMnemonic) {
+    return (
+      <div className="mt-3 space-y-2">
+        <div className="text-[11px] uppercase tracking-widest text-bolt">
+          Write this down — it's the only way to recover this wallet outside Nostr.
+        </div>
+        <code className="block card p-3 text-xs leading-relaxed break-words select-all">
+          {draftMnemonic}
+        </code>
+        <label className="flex items-center gap-2 text-[11px] text-muted">
+          <input
+            type="checkbox"
+            checked={confirmed}
+            onChange={(e) => setConfirmed(e.target.checked)}
+          />
+          I&apos;ve written it down somewhere safe.
+        </label>
+        <div className="flex gap-2">
+          <button
+            onClick={confirmCreate}
+            disabled={!confirmed}
+            className="btn-bolt disabled:opacity-30"
+          >
+            Back up to Nostr
+          </button>
+          <button onClick={cancelCreate} className="btn-ghost">Cancel</button>
+        </div>
+        {err && <div className="text-[11px] text-nostr/80">{err}</div>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      <div className="text-[11px] text-muted">
+        Self-custodial wallet. Mnemonic is NIP-44 encrypted to your pubkey and stored on your write relays.
+      </div>
+      <div className="flex gap-2 flex-wrap">
+        <button
+          onClick={startCreate}
+          disabled={mode === 'busy' || !identity}
+          className="btn-ghost disabled:opacity-30"
+        >
+          Create new
+        </button>
+        <button
+          onClick={restore}
+          disabled={mode === 'restoring' || mode === 'busy' || !identity}
+          className="btn-ghost disabled:opacity-30"
+        >
+          {mode === 'restoring' ? 'Restoring…' : 'Restore from Nostr'}
+        </button>
+      </div>
+      {!identity && (
+        <div className="text-[11px] text-muted">Sign in with Nostr to create or restore.</div>
+      )}
+      {err && <div className="text-[11px] text-nostr/80">{err}</div>}
+    </div>
+  );
+}

--- a/components/webln-wallet.tsx
+++ b/components/webln-wallet.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+// WebLN status surface for the account menu. There's no "connect" flow —
+// WebLN is provided by a browser extension (Alby, Mutiny) and is auto-
+// detected. The "Enable" button calls wl.enable() proactively so the first
+// boost doesn't have to wait on a permission prompt.
+
+import { useEffect, useState } from 'react';
+import { hasWebln } from '@/lib/v4v/webln';
+import { getErrorMessage } from '@/lib/util';
+
+export function WeblnWallet() {
+  const [detected, setDetected] = useState(false);
+  const [enabling, setEnabling] = useState(false);
+  const [enabled, setEnabled] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // hasWebln() reads window.webln, which is only defined client-side and
+  // may attach asynchronously after the extension's content script runs.
+  useEffect(() => {
+    setDetected(hasWebln());
+  }, []);
+
+  async function enable() {
+    setErr(null); setEnabling(true);
+    try {
+      await window.webln?.enable();
+      setEnabled(true);
+    } catch (e) {
+      setErr(getErrorMessage(e, 'enable failed'));
+    } finally { setEnabling(false); }
+  }
+
+  if (!detected) {
+    return (
+      <div className="mt-3 text-[11px] text-muted">
+        Not detected. Install <a href="https://getalby.com" target="_blank" rel="noopener" className="underline hover:text-bolt">Alby</a> or another WebLN browser extension.
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3 space-y-2">
+      <div className="text-[11px] text-muted">WebLN extension detected.</div>
+      {!enabled && (
+        <button onClick={enable} disabled={enabling} className="btn-ghost disabled:opacity-30">
+          {enabling ? 'Enabling…' : 'Enable for this site'}
+        </button>
+      )}
+      {enabled && <div className="text-[11px] text-muted">Enabled for this site.</div>}
+      {err && <div className="text-[11px] text-nostr/80">{err}</div>}
+    </div>
+  );
+}

--- a/lib/nostr/auth.ts
+++ b/lib/nostr/auth.ts
@@ -13,6 +13,12 @@ declare global {
         encrypt: (pubkey: string, plaintext: string) => Promise<string>;
         decrypt: (pubkey: string, ciphertext: string) => Promise<string>;
       };
+      // NIP-44 v2. Used to encrypt-to-self the Spark wallet mnemonic for the
+      // Nostr-hosted backup in lib/nostr/wallet-backup.ts.
+      nip44?: {
+        encrypt: (pubkey: string, plaintext: string) => Promise<string>;
+        decrypt: (pubkey: string, ciphertext: string) => Promise<string>;
+      };
     };
     webln?: {
       enable: () => Promise<void>;

--- a/lib/nostr/favorites.ts
+++ b/lib/nostr/favorites.ts
@@ -7,9 +7,18 @@ import { signAndPublish, type PublishedNote } from './publish';
 
 export const FAVORITES_D_TAG = 'boostmebitch:favorites';
 
+// Podcasting 2.0 podcast:guid is a UUID (v5 in spec, but tolerate any version).
+// Older versions of this app (and some other clients) wrote feed IDs or
+// live-episode strings into the i-tag — drop those on read so we don't ship
+// junk to /api/by-guid.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export interface FavoritesEvent {
   guids: string[];
   updatedAt: number; // unix seconds, from event.created_at
+  /** Guids the relay event had that didn't match UUID shape — exposed so
+   *  callers can offer the user a one-shot "clean up favorites" republish. */
+  droppedGuids: string[];
 }
 
 export async function fetchFavoriteGuids(
@@ -28,12 +37,15 @@ export async function fetchFavoriteGuids(
       if (!events.length) return null;
       const newest = events.sort((a, b) => b.created_at - a.created_at)[0];
       const guids: string[] = [];
+      const droppedGuids: string[] = [];
       for (const tag of newest.tags) {
         if (tag[0] !== 'i' || !tag[1]) continue;
         const m = /^podcast:guid:(.+)$/.exec(tag[1]);
-        if (m) guids.push(m[1]);
+        if (!m) continue;
+        if (UUID_RE.test(m[1])) guids.push(m[1]);
+        else droppedGuids.push(m[1]);
       }
-      return { guids, updatedAt: newest.created_at };
+      return { guids, updatedAt: newest.created_at, droppedGuids };
     } catch {
       return null;
     }

--- a/lib/nostr/index.ts
+++ b/lib/nostr/index.ts
@@ -40,3 +40,10 @@ export {
   schedulePublishFavorites,
   type FavoritesEvent,
 } from './favorites';
+
+export {
+  WALLET_BACKUP_KIND,
+  WALLET_BACKUP_D_TAG,
+  fetchEncryptedMnemonic,
+  publishEncryptedMnemonic,
+} from './wallet-backup';

--- a/lib/nostr/use-feed.ts
+++ b/lib/nostr/use-feed.ts
@@ -6,9 +6,11 @@ import type { DiscoveredNote } from './discover';
 /**
  * Stale-while-revalidate hook for any DiscoveredNote[] surface.
  *
- *   - Seed initial state from `storage.feedNotes.get(cacheKey)` so revisits
- *     paint cached notes synchronously instead of through the empty
- *     "searching nostr relays…" state.
+ *   - Initial render is deterministic (`notes === null`) so SSR and client
+ *     produce matching markup — no hydration mismatch.
+ *   - Right after mount, read `storage.feedNotes.get(cacheKey)` so revisits
+ *     paint cached notes within one frame instead of through the empty
+ *     "searching nostr relays…" state for the full network round-trip.
  *   - Re-seed + re-fetch whenever any of `deps` change (the per-podcast feed
  *     passes `[podcastGuid]`; the global feed passes `[]`).
  *   - Cache the new result on every successful load.
@@ -27,9 +29,7 @@ export function useNostrFeed({
   err: string | null;
   refresh: () => Promise<void>;
 } {
-  const [notes, setNotes] = useState<DiscoveredNote[] | null>(() =>
-    storage.feedNotes.get(cacheKey),
-  );
+  const [notes, setNotes] = useState<DiscoveredNote[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
@@ -48,7 +48,8 @@ export function useNostrFeed({
   }
 
   useEffect(() => {
-    setNotes(storage.feedNotes.get(cacheKey));
+    const cached = storage.feedNotes.get(cacheKey);
+    if (cached) setNotes(cached);
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);

--- a/lib/nostr/wallet-backup.ts
+++ b/lib/nostr/wallet-backup.ts
@@ -1,0 +1,74 @@
+'use client';
+
+// Nostr-backed encrypted backup for the Spark wallet mnemonic.
+//
+// Storage shape:
+//   - kind: 30078 (NIP-78, application-specific data)
+//   - d-tag: 'boostmebitch:wallet:spark' — stable identifier, replaceable
+//   - content: NIP-44 v2 encrypted-to-self ciphertext of the BIP-39 mnemonic
+//
+// Trust model: anyone with the user's nsec can decrypt this (same trust
+// boundary as login). The Nostr backup is convenience, not the only copy —
+// callers must show the mnemonic once on first generation so the user can
+// also write it down.
+//
+// Why kind:30078 and not NIP-60 (kind:17375): NIP-60 is Cashu-specific. We
+// own the schema here; sticking to NIP-78 keeps it explicit that this is
+// boostmebitch app data, not a portable Cashu wallet.
+
+import { withPool } from './pool';
+import { signAndPublish, type PublishedNote } from './publish';
+import { resolvePublishRelays } from './relays';
+import type { NostrIdentity } from './auth';
+
+export const WALLET_BACKUP_KIND = 30078;
+export const WALLET_BACKUP_D_TAG = 'boostmebitch:wallet:spark';
+
+function ensureNip44() {
+  if (typeof window === 'undefined' || !window.nostr?.nip44) {
+    throw new Error(
+      'Nostr signer does not expose NIP-44. Use Alby or nos2x with NIP-44 support.',
+    );
+  }
+  return window.nostr.nip44;
+}
+
+/** Decrypt the user's stored mnemonic, or null if no backup exists yet. */
+export async function fetchEncryptedMnemonic(
+  identity: NostrIdentity,
+): Promise<string | null> {
+  const relays = resolvePublishRelays(identity);
+  const event = await withPool(relays, async (pool) => {
+    const events = await pool.querySync(relays, {
+      kinds: [WALLET_BACKUP_KIND],
+      authors: [identity.pubkey],
+      '#d': [WALLET_BACKUP_D_TAG],
+      limit: 1,
+    });
+    if (!events.length) return null;
+    return events.sort((a, b) => b.created_at - a.created_at)[0];
+  });
+  if (!event || !event.content) return null;
+
+  const nip44 = ensureNip44();
+  return nip44.decrypt(identity.pubkey, event.content);
+}
+
+/** Encrypt-to-self and publish a new wallet backup event. */
+export async function publishEncryptedMnemonic(
+  identity: NostrIdentity,
+  mnemonic: string,
+): Promise<PublishedNote> {
+  const nip44 = ensureNip44();
+  const ciphertext = await nip44.encrypt(identity.pubkey, mnemonic);
+
+  return signAndPublish(
+    {
+      kind: WALLET_BACKUP_KIND,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [['d', WALLET_BACKUP_D_TAG]],
+      content: ciphertext,
+    },
+    resolvePublishRelays(identity),
+  );
+}

--- a/lib/podcast-meta.ts
+++ b/lib/podcast-meta.ts
@@ -1,0 +1,74 @@
+'use client';
+
+// Unified `/api/by-guid` resolver used by anything that needs a Podcast
+// from a podcast:guid identifier (favorites hydrator, global Nostr feed,
+// per-podcast feed). Layers four guards so the endpoint isn't hammered
+// when Podcast Index is unconfigured locally:
+//
+//   1. In-memory Map (fastest path within a page session).
+//   2. localStorage `bmb:pmeta:<guid>` cache (7-day TTL, survives reloads).
+//   3. sessionStorage circuit breaker — once /api/by-guid 5xxs in this tab,
+//      every subsequent caller short-circuits to null without a fetch.
+//   4. The actual fetch.
+//
+// Callers using the breaker manually (e.g. probe-first batch patterns)
+// can call `piMaybeUp()` before firing parallel resolves.
+
+import { storage } from './storage';
+import type { Podcast } from './types';
+
+const PI_BREAKER_KEY = 'bmb:pi:dead';
+
+const podcastMem = new Map<string, Podcast | null>();
+
+export function piMaybeUp(): boolean {
+  if (typeof window === 'undefined') return true;
+  try { return sessionStorage.getItem(PI_BREAKER_KEY) !== '1'; } catch { return true; }
+}
+
+export function tripPiBreaker() {
+  if (typeof window === 'undefined') return;
+  try { sessionStorage.setItem(PI_BREAKER_KEY, '1'); } catch {}
+}
+
+/** Reset the breaker (used after the user explicitly retries). */
+export function resetPiBreaker() {
+  if (typeof window === 'undefined') return;
+  try { sessionStorage.removeItem(PI_BREAKER_KEY); } catch {}
+}
+
+export async function resolvePodcastByGuid(guid: string): Promise<Podcast | null> {
+  if (podcastMem.has(guid)) return podcastMem.get(guid) ?? null;
+  const cached = storage.podcastMeta.get(guid);
+  if (cached) {
+    podcastMem.set(guid, cached);
+    return cached;
+  }
+  if (!piMaybeUp()) {
+    podcastMem.set(guid, null);
+    return null;
+  }
+  try {
+    const r = await fetch(`/api/by-guid?guid=${encodeURIComponent(guid)}`);
+    if (r.status >= 500) {
+      tripPiBreaker();
+      podcastMem.set(guid, null);
+      return null;
+    }
+    if (!r.ok) {
+      podcastMem.set(guid, null);
+      return null;
+    }
+    const { podcast } = (await r.json()) as { podcast: Podcast };
+    if (!podcast) {
+      podcastMem.set(guid, null);
+      return null;
+    }
+    podcastMem.set(guid, podcast);
+    storage.podcastMeta.set(guid, podcast);
+    return podcast;
+  } catch {
+    podcastMem.set(guid, null);
+    return null;
+  }
+}

--- a/lib/rss.ts
+++ b/lib/rss.ts
@@ -1,0 +1,160 @@
+// Server-only minimal RSS / Podcasting 2.0 parser. Used by
+// /api/feed-by-url to load a feed without hitting Podcast Index — useful
+// for local dev when PODCAST_INDEX_KEY isn't set. Hand-rolled regex parsing
+// is fragile by design; only fields we actually render are extracted, and
+// well-formed feeds with the standard `podcast:` namespace are assumed.
+
+import crypto from 'node:crypto';
+import type { Podcast, Episode, ValueBlock, ValueRecipient } from './types';
+
+function stripCdata(s: string): string {
+  return s.replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '$1').trim();
+}
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'");
+}
+
+function clean(s: string | null | undefined): string | undefined {
+  if (s == null) return undefined;
+  return decodeEntities(stripCdata(s));
+}
+
+function tag(xml: string, name: string): string | null {
+  const re = new RegExp(`<${name}\\b[^>]*>([\\s\\S]*?)</${name}>`, 'i');
+  const m = xml.match(re);
+  return m ? m[1] : null;
+}
+
+function attr(xml: string, tagName: string, name: string): string | null {
+  const re = new RegExp(`<${tagName}\\b[^>]*?\\s${name}="([^"]*)"[^>]*?/?>`, 'i');
+  const m = xml.match(re);
+  return m ? m[1] : null;
+}
+
+function parseValueBlock(xml: string): ValueBlock | null {
+  const block = tag(xml, 'podcast:value');
+  if (!block) return null;
+  // Header attrs live on the open tag, so re-match against the slice.
+  const opener = xml.match(/<podcast:value\b[^>]*>/i)?.[0] ?? '';
+  const type = opener.match(/\stype="([^"]*)"/i)?.[1] ?? 'lightning';
+  const method = opener.match(/\smethod="([^"]*)"/i)?.[1] ?? 'keysend';
+  const suggested = opener.match(/\ssuggested="([^"]*)"/i)?.[1];
+
+  const recipients: ValueRecipient[] = [];
+  const recipientRe = /<podcast:valueRecipient\b[^>]*\/?>(?:\s*<\/podcast:valueRecipient>)?/gi;
+  for (const match of block.matchAll(recipientRe)) {
+    const r = match[0];
+    const split = Number(r.match(/\ssplit="([^"]*)"/i)?.[1] ?? '0') || 0;
+    if (!split) continue;
+    const address = r.match(/\saddress="([^"]*)"/i)?.[1];
+    if (!address) continue;
+    recipients.push({
+      name: r.match(/\sname="([^"]*)"/i)?.[1],
+      type: r.match(/\stype="([^"]*)"/i)?.[1] ?? 'node',
+      address,
+      customKey: r.match(/\scustomKey="([^"]*)"/i)?.[1],
+      customValue: r.match(/\scustomValue="([^"]*)"/i)?.[1],
+      split,
+      fee: /fee="true"/i.test(r) || undefined,
+    });
+  }
+  if (!recipients.length) return null;
+  return { type, method, suggested, recipients };
+}
+
+// Synthetic numeric ID derived from the feed URL — keeps Podcast.id typed as
+// number and stable across reloads of the same URL. Negative space marks it
+// as "not a real Podcast Index ID" so it's distinguishable in logs.
+function syntheticId(url: string): number {
+  const hex = crypto.createHash('sha1').update(url).digest('hex').slice(0, 12);
+  return -Math.abs(parseInt(hex, 16) % 1_000_000_000);
+}
+
+function parseDuration(s: string | null | undefined): number | undefined {
+  if (!s) return undefined;
+  const trimmed = s.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed);
+  // hh:mm:ss or mm:ss
+  const parts = trimmed.split(':').map(Number);
+  if (parts.some(isNaN)) return undefined;
+  if (parts.length === 3) return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  if (parts.length === 2) return parts[0] * 60 + parts[1];
+  return undefined;
+}
+
+export async function fetchAndParseRss(url: string): Promise<{ podcast: Podcast; episodes: Episode[] }> {
+  const res = await fetch(url, {
+    headers: { 'User-Agent': process.env.APP_NAME ?? 'boostmebitch/0.1' },
+  });
+  if (!res.ok) throw new Error(`RSS fetch failed (${res.status})`);
+  const xml = await res.text();
+
+  // Split off <item> blocks; channel metadata lives before the first item.
+  const itemBlocks: string[] = [];
+  const itemRe = /<item\b[^>]*>([\s\S]*?)<\/item>/gi;
+  for (const m of xml.matchAll(itemRe)) itemBlocks.push(m[1]);
+  const firstItemIdx = xml.search(/<item\b/i);
+  const channelXml = firstItemIdx >= 0 ? xml.slice(0, firstItemIdx) : xml;
+
+  const id = syntheticId(url);
+  const title = clean(tag(channelXml, 'title')) ?? 'Untitled feed';
+  const description = clean(tag(channelXml, 'description'));
+  const author = clean(tag(channelXml, 'itunes:author'));
+  const podcastGuid = clean(tag(channelXml, 'podcast:guid'));
+  const link = clean(tag(channelXml, 'link'));
+  const image =
+    attr(channelXml, 'itunes:image', 'href') ??
+    clean(tag(tag(channelXml, 'image') ?? '', 'url')) ??
+    undefined;
+  const value = parseValueBlock(channelXml);
+
+  const podcast: Podcast = {
+    id,
+    podcastGuid,
+    title,
+    author,
+    description,
+    image,
+    url: url || link,
+    value,
+  };
+
+  const episodes: Episode[] = itemBlocks.map((itemXml, idx) => {
+    const eTitle = clean(tag(itemXml, 'title')) ?? `Episode ${idx + 1}`;
+    const eDesc = clean(tag(itemXml, 'description'));
+    const enclosureUrl = attr(itemXml, 'enclosure', 'url') ?? '';
+    const enclosureType = attr(itemXml, 'enclosure', 'type') ?? undefined;
+    const guid = clean(tag(itemXml, 'guid'));
+    const dateStr = clean(tag(itemXml, 'pubDate'));
+    const datePublished = dateStr ? Math.floor(new Date(dateStr).getTime() / 1000) : undefined;
+    const duration = parseDuration(clean(tag(itemXml, 'itunes:duration')));
+    const eImage = attr(itemXml, 'itunes:image', 'href') ?? undefined;
+    const eValue = parseValueBlock(itemXml) ?? value;
+
+    return {
+      id: -(idx + 1),
+      guid,
+      title: eTitle,
+      description: eDesc,
+      enclosureUrl,
+      enclosureType,
+      duration,
+      datePublished,
+      image: eImage,
+      feedId: id,
+      feedTitle: title,
+      feedImage: image,
+      podcastGuid,
+      value: eValue,
+    };
+  }).filter((e) => e.enclosureUrl);
+
+  return { podcast, episodes };
+}

--- a/lib/v4v/boost.ts
+++ b/lib/v4v/boost.ts
@@ -7,7 +7,9 @@
 import type { Boostagram, ValueBlock, ValueRecipient, BoostResult } from '@/lib/types';
 import { hasNwc, nwcKeysend, nwcPayInvoice } from './nwc';
 import { hasWebln, weblnKeysend, weblnPayInvoice } from './webln';
+import { hasSpark, sparkPayInvoice } from './spark';
 import { fetchLnInvoice } from './lnaddr';
+import { registerBoostMetadata } from './boostbox';
 
 // TLV custom record number for podcast boostagrams (Podcasting 2.0 spec).
 // The boostagram JSON already carries `sender_id`, so we don't add a separate
@@ -16,13 +18,17 @@ import { fetchLnInvoice } from './lnaddr';
 // customKey/customValue pairs.
 const TLV_BOOSTAGRAM = 7629169;
 
-export type Rail = 'nwc' | 'webln';
+export type Rail = 'nwc' | 'webln' | 'spark';
 
 // Re-export so callers can import from one place
 export type { BoostResult };
 
+// Priority: NWC (explicit user setup) > Spark (auto-provisioned self-custodial)
+// > WebLN (browser extension fallback). Users can override per-boost in the
+// modal; this is just the default.
 export function pickRail(): Rail | null {
   if (hasNwc()) return 'nwc';
+  if (hasSpark()) return 'spark';
   if (hasWebln()) return 'webln';
   return null;
 }
@@ -81,6 +87,12 @@ function recordsForKeysend(
   return records;
 }
 
+// Toggle BoostBox sidechannel for lnaddress legs. When on, the boostagram is
+// POSTed to BoostBox first and the returned `desc` string (which carries the
+// short URL aggregators look for) is passed as the LNURL-pay comment. Default
+// off so the existing comment-only behavior is preserved.
+const BOOSTBOX_ENABLED = process.env.NEXT_PUBLIC_BOOSTBOX_ENABLED === 'true';
+
 async function payOne(
   recipient: ValueRecipient,
   sats: number,
@@ -92,19 +104,38 @@ async function payOne(
 
   try {
     if (recipient.type === 'lnaddress') {
+      const recPerRecipient: Boostagram = {
+        ...boostagram,
+        value_msat: sats * 1000,
+        name: recipient.name,
+      };
+      let comment = boostagram.message;
+      if (BOOSTBOX_ENABLED) {
+        const bb = await registerBoostMetadata(recPerRecipient);
+        if (bb) comment = bb.desc;
+      }
       const invoice = await fetchLnInvoice({
         address: recipient.address,
         amount_msat: sats * 1000,
-        comment: boostagram.message,
+        comment,
       });
-      const preimage =
-        rail === 'nwc'
-          ? await nwcPayInvoice(invoice)
-          : await weblnPayInvoice(invoice);
+      let preimage: string;
+      if (rail === 'nwc') preimage = await nwcPayInvoice(invoice);
+      else if (rail === 'spark') preimage = await sparkPayInvoice(invoice);
+      else preimage = await weblnPayInvoice(invoice);
       return { ...base, ok: true, preimage };
     }
 
-    // type === 'node' → keysend
+    // type === 'node' → keysend. Spark has no keysend path, so node-pubkey
+    // legs degrade with a clear error rather than silently failing the boost.
+    if (rail === 'spark') {
+      return {
+        ...base,
+        ok: false,
+        error: 'Spark rail does not support keysend (node-pubkey recipient)',
+      };
+    }
+
     const recPerRecipient: Boostagram = {
       ...boostagram,
       value_msat: sats * 1000,
@@ -139,7 +170,7 @@ export async function sendBoost(args: {
   onProgress?: (r: BoostResult, index: number, total: number) => void;
 }): Promise<BoostResult[]> {
   const rail = args.rail ?? pickRail();
-  if (!rail) throw new Error('No payment provider available (connect NWC or WebLN)');
+  if (!rail) throw new Error('No payment provider available (connect NWC, Spark, or WebLN)');
 
   const recipients = args.value.recipients;
   const splits = splitSats(args.totalSats, recipients);

--- a/lib/v4v/boostbox.ts
+++ b/lib/v4v/boostbox.ts
@@ -1,0 +1,86 @@
+'use client';
+
+// BoostBox metadata sidechannel — https://github.com/ChadFarrow/boostbox
+//
+// Carries the structured boostagram metadata that can't ride on an LNURL-pay
+// `comment` field (too short / unstructured) or a Spark BOLT11 description.
+// Sender POSTs the boostagram, gets back a short URL + a canonical "desc"
+// string in the form:
+//
+//   rss::payment::boost https://boostbox.cloud/boost/<id> [message]
+//
+// That `desc` string is what aggregators (Helipad-style) look for in invoice
+// descriptions and LNURL `comment` fields. Resolvers fetch the URL and pull
+// the original metadata back out of the `x-rss-payment` HTTP header.
+//
+// This is rail-agnostic: NWC, WebLN, AND Spark lnaddress legs all benefit,
+// not just Spark. Node-pubkey keysend legs still ship the boostagram
+// in-band via TLV 7629169 in lib/v4v/boost.ts and don't need this.
+
+import type { Boostagram } from '@/lib/types';
+
+const DEFAULT_BASE_URL = 'https://boostbox.cloud';
+const DEFAULT_API_KEY = 'v4v4me'; // public demo key per BoostBox README
+
+const BASE_URL = process.env.NEXT_PUBLIC_BOOSTBOX_URL || DEFAULT_BASE_URL;
+const API_KEY = process.env.NEXT_PUBLIC_BOOSTBOX_API_KEY || DEFAULT_API_KEY;
+
+interface BoostBoxResponse {
+  id: string;
+  url: string;
+  desc: string;
+}
+
+/**
+ * POST a boostagram to BoostBox. Returns the canonical `desc` string
+ * (`rss::payment::boost <url> [message]`) which can be used as the
+ * LNURL-pay comment or BOLT11 description. Returns null on failure so
+ * callers can fall back to the raw message without aborting the boost.
+ */
+export async function registerBoostMetadata(
+  boostagram: Boostagram,
+): Promise<BoostBoxResponse | null> {
+  try {
+    const res = await fetch(`${BASE_URL}/boost`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Api-Key': API_KEY,
+      },
+      body: JSON.stringify(toBoostBoxBody(boostagram)),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as BoostBoxResponse;
+    if (!data?.url) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+// BoostBox's required fields: action, split, value_msat, value_msat_total,
+// timestamp (ISO-8601). Map the in-flight Boostagram onto that shape; pass
+// optional fields through verbatim where names match.
+function toBoostBoxBody(b: Boostagram): Record<string, unknown> {
+  return {
+    action: b.action,
+    split: 100, // weight-aware splits live in the value block, not here
+    value_msat: b.value_msat ?? b.value_msat_total ?? 0,
+    value_msat_total: b.value_msat_total ?? b.value_msat ?? 0,
+    timestamp: new Date().toISOString(),
+    message: b.message,
+    app_name: b.app_name,
+    sender_name: b.sender_name,
+    sender_id: b.sender_id,
+    podcast: b.podcast,
+    episode: b.episode,
+    feedID: b.feedID,
+    itemID: b.itemID,
+    url: b.url,
+    ts: b.ts,
+    uuid: b.uuid,
+    remote_feed_guid: b.remote_feed_guid,
+    episode_guid: b.episode_guid,
+    remote_item_guid: b.remote_item_guid,
+  };
+}

--- a/lib/v4v/spark.ts
+++ b/lib/v4v/spark.ts
@@ -137,6 +137,7 @@ export async function sparkPayInvoice(invoice: string): Promise<string> {
   // estimate today but pass through the prepareResponse as the SDK requires.
   const prepared = await sdk.prepareSendPayment({ paymentRequest: invoice });
   const res = await sdk.sendPayment({ prepareResponse: prepared });
+  console.log('[spark] sendPayment response:', JSON.stringify(res, (_k, v) => typeof v === 'bigint' ? v.toString() : v, 2));
   const preimage = res?.payment?.preimage ?? res?.payment?.details?.htlcDetails?.preimage;
   if (!preimage) throw new Error('Spark sendPayment returned no preimage');
   return preimage as string;

--- a/lib/v4v/spark.ts
+++ b/lib/v4v/spark.ts
@@ -1,0 +1,92 @@
+'use client';
+
+// Spark rail — Breez Spark SDK adapter. Self-custodial wallet whose mnemonic
+// is bootstrapped from a NIP-44-encrypted backup on Nostr relays
+// (lib/nostr/wallet-backup.ts).
+//
+// Send capabilities: BOLT11 invoices and Spark addresses. Keysend is NOT
+// supported by this rail — node-pubkey value-block legs degrade in
+// lib/v4v/boost.ts. lnaddress legs work because payOne fetches a BOLT11 from
+// the LNURL-pay endpoint first.
+//
+// SDK wiring is intentionally stubbed below: the package name and exact init
+// signature for @breeztech/breez-sdk-spark may shift, and we don't want the
+// dependency to break `next build` until we wire it for real. Drop the real
+// import + connect call into the TODO blocks; the rest of the rail
+// (hasSpark / sparkPayInvoice / sparkDisconnect) is the stable surface that
+// boost.ts depends on.
+
+// Replace `unknown` with the real SDK instance type when wiring.
+type SparkSdk = unknown;
+
+let sdk: SparkSdk | null = null;
+let activePubkey: string | null = null;
+
+/** True once a wallet has been initialized for the current session. */
+export function hasSpark(): boolean {
+  return sdk !== null;
+}
+
+/** Pubkey the loaded wallet was bootstrapped for, for sanity-checking on identity changes. */
+export function sparkOwner(): string | null {
+  return activePubkey;
+}
+
+/**
+ * Initialize the Spark SDK from a BIP-39 mnemonic. Call this once after
+ * wallet-backup.ts hands you the decrypted seed, or after a fresh mnemonic
+ * is generated for first-time users.
+ */
+export async function sparkInitFromMnemonic(args: {
+  mnemonic: string;
+  ownerPubkey: string;
+  network?: 'mainnet' | 'testnet';
+}): Promise<void> {
+  // TODO(spark-sdk): wire the real SDK init.
+  //
+  //   const { connect, defaultConfig } = await import('@breeztech/breez-sdk-spark');
+  //   const config = defaultConfig({
+  //     network: args.network ?? 'mainnet',
+  //     apiKey: process.env.NEXT_PUBLIC_BREEZ_API_KEY,
+  //   });
+  //   sdk = await connect({
+  //     mnemonic: args.mnemonic,
+  //     storageDir: `bmb-spark-${args.ownerPubkey.slice(0, 8)}`,
+  //     config,
+  //   });
+  //   activePubkey = args.ownerPubkey;
+  //
+  // Until then, mark the wallet as "not ready" so callers fall through to
+  // NWC/WebLN.
+  void args;
+  throw new Error('Spark SDK not yet wired — see TODO in lib/v4v/spark.ts');
+}
+
+/** Pay a BOLT11 invoice via the Spark SDK. Returns the payment preimage. */
+export async function sparkPayInvoice(invoice: string): Promise<string> {
+  if (!sdk) throw new Error('Spark wallet not initialized');
+  // TODO(spark-sdk):
+  //   const res = await (sdk as any).sendPayment({ paymentRequest: invoice });
+  //   return res.payment.preimage;
+  void invoice;
+  throw new Error('Spark SDK not yet wired — see TODO in lib/v4v/spark.ts');
+}
+
+/**
+ * Generate a fresh BIP-39 mnemonic for first-time wallet setup. Implementation
+ * detail of the SDK; until wired, callers can supply their own mnemonic from
+ * @scure/bip39 if they want to test the relay backup flow without the SDK.
+ */
+export async function sparkGenerateMnemonic(): Promise<string> {
+  // TODO(spark-sdk): use the SDK's mnemonic helper, or import from @scure/bip39.
+  //   const { generateMnemonic, wordlist } = await import('@scure/bip39/wordlists/english');
+  //   return generateMnemonic(wordlist);
+  throw new Error('Spark mnemonic generator not yet wired');
+}
+
+/** Tear down the SDK on sign-out. */
+export async function sparkDisconnect(): Promise<void> {
+  // TODO(spark-sdk): await (sdk as any)?.disconnect();
+  sdk = null;
+  activePubkey = null;
+}

--- a/lib/v4v/spark.ts
+++ b/lib/v4v/spark.ts
@@ -138,9 +138,20 @@ export async function sparkPayInvoice(invoice: string): Promise<string> {
   const prepared = await sdk.prepareSendPayment({ paymentRequest: invoice });
   const res = await sdk.sendPayment({ prepareResponse: prepared });
   console.log('[spark] sendPayment response:', JSON.stringify(res, (_k, v) => typeof v === 'bigint' ? v.toString() : v, 2));
-  const preimage = res?.payment?.preimage ?? res?.payment?.details?.htlcDetails?.preimage;
-  if (!preimage) throw new Error('Spark sendPayment returned no preimage');
-  return preimage as string;
+  const payment = res?.payment;
+  if (!payment) throw new Error('Spark sendPayment returned no payment');
+  const status = String(payment.status ?? '').toLowerCase();
+  if (status === 'failed') throw new Error('Spark payment failed');
+  // status: 'completed' | 'pending' both mean the HTLC routed and sats are
+  // committed. preimage is optional on Payment.details.htlcDetails — it's
+  // undefined while htlcStatus === 'waitingForPreimage', which is common at
+  // the moment sendPayment resolves. Don't gate boost success on it; the
+  // BoostResult.preimage field is optional and unread by the UI.
+  const preimage: string =
+    payment.details?.htlcDetails?.preimage ??
+    payment.details?.preimage ??
+    '';
+  return preimage;
 }
 
 /**

--- a/lib/v4v/spark.ts
+++ b/lib/v4v/spark.ts
@@ -9,23 +9,46 @@
 // lib/v4v/boost.ts. lnaddress legs work because payOne fetches a BOLT11 from
 // the LNURL-pay endpoint first.
 //
-// SDK wiring is intentionally stubbed below: the package name and exact init
-// signature for @breeztech/breez-sdk-spark may shift, and we don't want the
-// dependency to break `next build` until we wire it for real. Drop the real
-// import + connect call into the TODO blocks; the rest of the rail
-// (hasSpark / sparkPayInvoice / sparkDisconnect) is the stable surface that
-// boost.ts depends on.
+// Init is two-stage because the SDK ships as a WebAssembly module. The
+// default export of '@breeztech/breez-sdk-spark' is the WASM loader; it
+// must run once before any other SDK call. We dynamic-import inside
+// sparkInitFromMnemonic so the ~1MB WASM payload only lands in the bundle
+// the first time a user actually opens a Spark wallet.
 
-// Replace `unknown` with the real SDK instance type when wiring.
-type SparkSdk = unknown;
+import { sha256 } from '@noble/hashes/sha2.js';
+import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
 
-// Sentinel used by stub-mode init so hasSpark() flips true and the rail
-// becomes selectable in the UI before the real SDK is wired. Replace this
-// with the actual connect() return value when uncommenting the TODOs below.
-const STUB_SDK: SparkSdk = { __stub: true };
+// SDK instance + module references are loosely typed because the SDK's
+// generated wasm bindings change frequently across minor versions; we
+// pin the public surface (hasSpark / sparkPayInvoice / sparkDisconnect)
+// and let TypeScript validate at the call boundary.
+type SparkSdk = {
+  sendPayment: (req: any) => Promise<any>;
+  prepareSendPayment: (req: any) => Promise<any>;
+  receivePayment: (req: any) => Promise<any>;
+  disconnect: () => Promise<void>;
+  getInfo: (req: any) => Promise<any>;
+  addEventListener: (listener: { onEvent: (e: SparkSdkEvent) => void }) => Promise<string>;
+  removeEventListener: (id: string) => Promise<boolean>;
+};
+
+// Mirror of @breeztech/breez-sdk-spark's SdkEvent discriminated union.
+// Re-declared here so callers can subscribe without dragging the SDK
+// types into client components.
+export type SparkSdkEvent =
+  | { type: 'synced' }
+  | { type: 'unclaimedDeposits'; unclaimedDeposits: unknown[] }
+  | { type: 'claimedDeposits'; claimedDeposits: unknown[] }
+  | { type: 'newDeposits'; newDeposits: unknown[] }
+  | { type: 'paymentSucceeded'; payment: unknown }
+  | { type: 'paymentPending'; payment: unknown }
+  | { type: 'paymentFailed'; payment: unknown }
+  | { type: 'optimization'; optimizationEvent: unknown }
+  | { type: 'lightningAddressChanged'; lightningAddress?: unknown };
 
 let sdk: SparkSdk | null = null;
 let activePubkey: string | null = null;
+let wasmInitialized = false;
 
 // Components reading hasSpark() during render need to refresh when the
 // module-level state flips outside their own tree (e.g. the auto-restore in
@@ -53,6 +76,15 @@ export function sparkOwner(): string | null {
   return activePubkey;
 }
 
+// storageDir suffix derived from the mnemonic so two wallets for the same
+// pubkey (rare but possible: disconnect → create-new with new seed) get
+// different SDK storage directories. Keying on ownerPubkey alone would
+// collide and either fail the second init or corrupt the first wallet.
+function walletStorageDir(ownerPubkey: string, mnemonic: string): string {
+  const walletId = bytesToHex(sha256(utf8ToBytes(mnemonic))).slice(0, 8);
+  return `bmb-spark-${ownerPubkey.slice(0, 8)}-${walletId}`;
+}
+
 /**
  * Initialize the Spark SDK from a BIP-39 mnemonic. Call this once after
  * wallet-backup.ts hands you the decrypted seed, or after a fresh mnemonic
@@ -61,35 +93,38 @@ export function sparkOwner(): string | null {
 export async function sparkInitFromMnemonic(args: {
   mnemonic: string;
   ownerPubkey: string;
-  network?: 'mainnet' | 'testnet';
+  // Spark SDK supports `mainnet` and `regtest` only — there's no public
+  // testnet for Spark. Use `regtest` against a local node for development;
+  // first-boost smoke testing on mainnet with a few sats is the realistic
+  // path.
+  network?: 'mainnet' | 'regtest';
 }): Promise<void> {
-  // TODO(spark-sdk): wire the real SDK init.
-  //
-  //   const { connect, defaultConfig } = await import('@breeztech/breez-sdk-spark');
-  //   const config = defaultConfig({
-  //     network: args.network ?? 'mainnet',
-  //     apiKey: process.env.NEXT_PUBLIC_BREEZ_API_KEY,
-  //   });
-  //   sdk = await connect({
-  //     mnemonic: args.mnemonic,
-  //     // WARNING: storageDir keyed on ownerPubkey alone collides if the user
-  //     // ever creates a second wallet for the same Nostr identity (e.g.
-  //     // disconnect → Create new). The Breez SDK will either reject the
-  //     // init or corrupt the existing wallet's state. Before flipping this
-  //     // on, switch the suffix to a wallet-specific id — e.g. the first 8
-  //     // hex chars of sha256(mnemonic) — so each seed gets its own dir:
-  //     //   const walletId = sha256(args.mnemonic).slice(0, 8);
-  //     //   storageDir: `bmb-spark-${args.ownerPubkey.slice(0, 8)}-${walletId}`,
-  //     // The SparkWallet UI already confirms the relay-side overwrite; the
-  //     // disk-side guard has to live here.
-  //     storageDir: `bmb-spark-${args.ownerPubkey.slice(0, 8)}`,
-  //     config,
-  //   });
-  //   activePubkey = args.ownerPubkey;
-  //
-  // Stub-mode: register the wallet as initialized so the UI surfaces it.
-  // Payments still throw (sparkPayInvoice) until the real SDK lands.
-  sdk = STUB_SDK;
+  const apiKey = process.env.NEXT_PUBLIC_BREEZ_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      'NEXT_PUBLIC_BREEZ_API_KEY is not set. Add it to .env.local and restart the dev server.',
+    );
+  }
+
+  // Dynamic import keeps the WASM out of the initial bundle.
+  const mod = await import('@breeztech/breez-sdk-spark');
+  if (!wasmInitialized) {
+    // Default export loads + instantiates the WebAssembly binary. Idempotent
+    // per-load but cheap to guard.
+    await (mod.default as () => Promise<void>)();
+    wasmInitialized = true;
+  }
+
+  const config = mod.defaultConfig(args.network ?? 'mainnet');
+  config.apiKey = apiKey;
+
+  const instance = await mod.connect({
+    config,
+    seed: { type: 'mnemonic', mnemonic: args.mnemonic },
+    storageDir: walletStorageDir(args.ownerPubkey, args.mnemonic),
+  });
+
+  sdk = instance as unknown as SparkSdk;
   activePubkey = args.ownerPubkey;
   notify();
 }
@@ -97,18 +132,21 @@ export async function sparkInitFromMnemonic(args: {
 /** Pay a BOLT11 invoice via the Spark SDK. Returns the payment preimage. */
 export async function sparkPayInvoice(invoice: string): Promise<string> {
   if (!sdk) throw new Error('Spark wallet not initialized');
-  // TODO(spark-sdk):
-  //   const res = await (sdk as any).sendPayment({ paymentRequest: invoice });
-  //   return res.payment.preimage;
-  void invoice;
-  throw new Error('Spark SDK not yet wired — see TODO in lib/v4v/spark.ts');
+  // Two-step prepare-then-send is required by the Spark SDK so the caller
+  // could surface fees ahead of the user committing. We don't expose the
+  // estimate today but pass through the prepareResponse as the SDK requires.
+  const prepared = await sdk.prepareSendPayment({ paymentRequest: invoice });
+  const res = await sdk.sendPayment({ prepareResponse: prepared });
+  const preimage = res?.payment?.preimage ?? res?.payment?.details?.htlcDetails?.preimage;
+  if (!preimage) throw new Error('Spark sendPayment returned no preimage');
+  return preimage as string;
 }
 
 /**
- * Generate a fresh BIP-39 mnemonic. Stub-mode uses @scure/bip39 directly so
- * the relay backup flow is exercisable before the SDK lands; swap this for
- * the SDK's own helper once wired (the resulting mnemonic should be format-
- * compatible — both produce standard BIP-39 phrases).
+ * Generate a fresh BIP-39 mnemonic. Uses @scure/bip39 directly — the SDK
+ * also ships a helper but @scure is already on disk via nostr-tools and
+ * produces format-compatible output, so we don't pay the WASM init cost
+ * just to mint a phrase.
  */
 export async function sparkGenerateMnemonic(): Promise<string> {
   const { generateMnemonic } = await import('@scure/bip39');
@@ -118,8 +156,63 @@ export async function sparkGenerateMnemonic(): Promise<string> {
 
 /** Tear down the SDK on sign-out. */
 export async function sparkDisconnect(): Promise<void> {
-  // TODO(spark-sdk): await (sdk as any)?.disconnect();
+  if (sdk) {
+    try { await sdk.disconnect(); } catch { /* best effort */ }
+  }
   sdk = null;
   activePubkey = null;
   notify();
+}
+
+/** Fetch the wallet's current balance + identity pubkey. */
+export async function sparkGetInfo(): Promise<{ balanceSats: number; identityPubkey?: string } | null> {
+  if (!sdk) return null;
+  try {
+    const info = await sdk.getInfo({});
+    return {
+      balanceSats: Number(info?.balanceSats ?? 0),
+      identityPubkey: info?.identityPubkey,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Subscribe to SDK events (`paymentSucceeded`, `claimedDeposits`, `synced`,
+ * etc.). Returns an unsubscribe fn. Use this instead of polling getInfo —
+ * the balance reflects the new state synchronously inside the event,
+ * because the SDK has already finished its claim/settle bookkeeping.
+ */
+export async function subscribeSparkEvents(
+  onEvent: (e: SparkSdkEvent) => void,
+): Promise<() => void> {
+  if (!sdk) return () => {};
+  const id = await sdk.addEventListener({ onEvent });
+  return () => {
+    if (sdk) sdk.removeEventListener(id).catch(() => {});
+  };
+}
+
+/**
+ * Generate a BOLT11 invoice the user can pay from any other Lightning wallet
+ * to fund this Spark wallet. Returns the invoice string and the fee Spark
+ * will charge to settle the incoming payment (in sats).
+ */
+export async function sparkReceiveInvoice(args: {
+  amountSats?: number;
+  description?: string;
+}): Promise<{ invoice: string; feeSats: number }> {
+  if (!sdk) throw new Error('Spark wallet not initialized');
+  const res = await (sdk as any).receivePayment({
+    paymentMethod: {
+      type: 'bolt11Invoice',
+      description: args.description ?? 'BoostMeBitch Spark deposit',
+      amountSats: args.amountSats,
+    },
+  });
+  return {
+    invoice: String(res?.paymentRequest ?? ''),
+    feeSats: Number(res?.fee ?? 0),
+  };
 }

--- a/lib/v4v/spark.ts
+++ b/lib/v4v/spark.ts
@@ -137,7 +137,6 @@ export async function sparkPayInvoice(invoice: string): Promise<string> {
   // estimate today but pass through the prepareResponse as the SDK requires.
   const prepared = await sdk.prepareSendPayment({ paymentRequest: invoice });
   const res = await sdk.sendPayment({ prepareResponse: prepared });
-  console.log('[spark] sendPayment response:', JSON.stringify(res, (_k, v) => typeof v === 'bigint' ? v.toString() : v, 2));
   const payment = res?.payment;
   if (!payment) throw new Error('Spark sendPayment returned no payment');
   const status = String(payment.status ?? '').toLowerCase();

--- a/lib/v4v/spark.ts
+++ b/lib/v4v/spark.ts
@@ -19,8 +19,29 @@
 // Replace `unknown` with the real SDK instance type when wiring.
 type SparkSdk = unknown;
 
+// Sentinel used by stub-mode init so hasSpark() flips true and the rail
+// becomes selectable in the UI before the real SDK is wired. Replace this
+// with the actual connect() return value when uncommenting the TODOs below.
+const STUB_SDK: SparkSdk = { __stub: true };
+
 let sdk: SparkSdk | null = null;
 let activePubkey: string | null = null;
+
+// Components reading hasSpark() during render need to refresh when the
+// module-level state flips outside their own tree (e.g. the auto-restore in
+// nostr-auth.tsx fires while the account menu is already open). Listeners
+// are notified on every init/disconnect so the UI re-reads.
+const listeners = new Set<() => void>();
+
+function notify() {
+  listeners.forEach((fn) => { try { fn(); } catch { /* ignore */ } });
+}
+
+/** Subscribe to wallet state changes. Returns an unsubscribe fn. */
+export function subscribeSpark(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}
 
 /** True once a wallet has been initialized for the current session. */
 export function hasSpark(): boolean {
@@ -51,15 +72,26 @@ export async function sparkInitFromMnemonic(args: {
   //   });
   //   sdk = await connect({
   //     mnemonic: args.mnemonic,
+  //     // WARNING: storageDir keyed on ownerPubkey alone collides if the user
+  //     // ever creates a second wallet for the same Nostr identity (e.g.
+  //     // disconnect → Create new). The Breez SDK will either reject the
+  //     // init or corrupt the existing wallet's state. Before flipping this
+  //     // on, switch the suffix to a wallet-specific id — e.g. the first 8
+  //     // hex chars of sha256(mnemonic) — so each seed gets its own dir:
+  //     //   const walletId = sha256(args.mnemonic).slice(0, 8);
+  //     //   storageDir: `bmb-spark-${args.ownerPubkey.slice(0, 8)}-${walletId}`,
+  //     // The SparkWallet UI already confirms the relay-side overwrite; the
+  //     // disk-side guard has to live here.
   //     storageDir: `bmb-spark-${args.ownerPubkey.slice(0, 8)}`,
   //     config,
   //   });
   //   activePubkey = args.ownerPubkey;
   //
-  // Until then, mark the wallet as "not ready" so callers fall through to
-  // NWC/WebLN.
-  void args;
-  throw new Error('Spark SDK not yet wired — see TODO in lib/v4v/spark.ts');
+  // Stub-mode: register the wallet as initialized so the UI surfaces it.
+  // Payments still throw (sparkPayInvoice) until the real SDK lands.
+  sdk = STUB_SDK;
+  activePubkey = args.ownerPubkey;
+  notify();
 }
 
 /** Pay a BOLT11 invoice via the Spark SDK. Returns the payment preimage. */
@@ -73,15 +105,15 @@ export async function sparkPayInvoice(invoice: string): Promise<string> {
 }
 
 /**
- * Generate a fresh BIP-39 mnemonic for first-time wallet setup. Implementation
- * detail of the SDK; until wired, callers can supply their own mnemonic from
- * @scure/bip39 if they want to test the relay backup flow without the SDK.
+ * Generate a fresh BIP-39 mnemonic. Stub-mode uses @scure/bip39 directly so
+ * the relay backup flow is exercisable before the SDK lands; swap this for
+ * the SDK's own helper once wired (the resulting mnemonic should be format-
+ * compatible — both produce standard BIP-39 phrases).
  */
 export async function sparkGenerateMnemonic(): Promise<string> {
-  // TODO(spark-sdk): use the SDK's mnemonic helper, or import from @scure/bip39.
-  //   const { generateMnemonic, wordlist } = await import('@scure/bip39/wordlists/english');
-  //   return generateMnemonic(wordlist);
-  throw new Error('Spark mnemonic generator not yet wired');
+  const { generateMnemonic } = await import('@scure/bip39');
+  const { wordlist } = await import('@scure/bip39/wordlists/english.js');
+  return generateMnemonic(wordlist);
 }
 
 /** Tear down the SDK on sign-out. */
@@ -89,4 +121,5 @@ export async function sparkDisconnect(): Promise<void> {
   // TODO(spark-sdk): await (sdk as any)?.disconnect();
   sdk = null;
   activePubkey = null;
+  notify();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,14 @@
       "name": "boostmebitch",
       "version": "0.1.0",
       "dependencies": {
+        "@breeztech/breez-sdk-spark": "^0.13.6",
         "@getalby/sdk": "^5.1.0",
+        "@scure/bip39": "^2.0.1",
         "@types/canvas-confetti": "^1.9.0",
         "canvas-confetti": "^1.9.4",
         "next": "^15.1.6",
         "nostr-tools": "^2.10.4",
+        "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "zustand": "^5.0.3"
@@ -38,6 +41,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@breeztech/breez-sdk-spark": {
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.13.6.tgz",
+      "integrity": "sha512-vu5Zw2UV4Oe2lLxRPqMcPruhAlJTuRLXzf7yButcfj5mZ/Ea4LID1AC7EYwdbGGt8crdMYxu7qgT1U1BbyScKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "optionalDependencies": {
+        "better-sqlite3": "^12.2.0",
+        "pg": "^8.18.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1061,6 +1077,27 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.23",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
@@ -1074,6 +1111,21 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1085,6 +1137,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/braces": {
@@ -1132,6 +1206,31 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/camelcase-css": {
@@ -1212,6 +1311,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -1248,6 +1354,32 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1279,6 +1411,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
@@ -1295,6 +1437,16 @@
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -1339,6 +1491,13 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1366,6 +1525,13 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1390,6 +1556,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -1416,6 +1589,41 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1533,6 +1741,36 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -1562,6 +1800,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/next": {
       "version": "15.5.15",
@@ -1643,6 +1888,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
@@ -1709,12 +1967,118 @@
         "node": ">= 6"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pg": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.3.0"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1918,6 +2282,97 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1938,6 +2393,22 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
     },
     "node_modules/react": {
       "version": "19.2.5",
@@ -1968,6 +2439,21 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -2040,6 +2526,27 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -2104,11 +2611,88 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2210,6 +2794,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -2307,6 +2921,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2363,8 +2990,25 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.4"
+      }
     },
     "node_modules/zustand": {
       "version": "5.0.12",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@getalby/sdk": "^5.1.0",
+    "@scure/bip39": "^2.0.1",
     "@types/canvas-confetti": "^1.9.0",
     "canvas-confetti": "^1.9.4",
     "next": "^15.1.6",

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@breeztech/breez-sdk-spark": "^0.13.6",
     "@getalby/sdk": "^5.1.0",
     "@scure/bip39": "^2.0.1",
     "@types/canvas-confetti": "^1.9.0",
     "canvas-confetti": "^1.9.4",
     "next": "^15.1.6",
     "nostr-tools": "^2.10.4",
+    "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zustand": "^5.0.3"


### PR DESCRIPTION
Adds three new modules behind the v4v swap-out boundary so a Spark wallet
can be bootstrapped from a NIP-44-encrypted mnemonic on Nostr relays and
participate in boosts as a third rail alongside NWC and WebLN.

- lib/v4v/spark.ts — Spark SDK adapter with init/pay-invoice/disconnect
  surface. SDK calls are stubbed with TODO blocks so next build stays
  green until the @breeztech/breez-sdk-spark WASM init is wired in.
- lib/nostr/wallet-backup.ts — kind:30078 with d-tag
  boostmebitch:wallet:spark, NIP-44 v2 encrypt-to-self of the BIP-39
  mnemonic. Trust model documented inline.
- lib/v4v/boostbox.ts — POSTs the boostagram to BoostBox and returns the
  rss::payment::boost desc string for use as the LNURL-pay comment, so
  lnaddress legs aren't metadata-degraded vs keysend. Gated on
  NEXT_PUBLIC_BOOSTBOX_ENABLED so existing flows are unchanged.
- lib/v4v/boost.ts — Rail extended to 'spark', pickRail priority is
  NWC > Spark > WebLN, lnaddress branch dispatches to sparkPayInvoice,
  node-pubkey legs on Spark degrade with a clear keysend-unsupported
  error rather than silently failing.
- lib/nostr/auth.ts — declare window.nostr.nip44 for the encrypt/decrypt
  calls used by wallet-backup.

https://claude.ai/code/session_01BQdphVNw9xtEWCz6hw4Jus