### PR TITLE
Add BoostBox support for LNURL boosts and intermix in global feed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,11 @@ PODCAST_INDEX_SECRET=
 
 # Optional: app identity for Podcast Index User-Agent
 APP_NAME=boostmebitch
+
+# BoostBox metadata service (https://github.com/ChadFarrow/boostbox)
+# Used on the LNURL leg of boosts to ship the boostagram out-of-band via the
+# LUD-21 comment field. The default URL points at tardbox.com; the API key
+# below is the public reference key — replace it with the key for whatever
+# BoostBox instance you're hitting (tardbox.com runs its own).
+BOOSTBOX_URL=https://tardbox.com
+BOOSTBOX_API_KEY=v4v4me

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Path alias: `@/*` maps to the repo root (`tsconfig.json` `baseUrl: "."`). Import
 
 The Podcast Index credentials (`PODCAST_INDEX_KEY` / `PODCAST_INDEX_SECRET`) must never reach the browser. Enforced by file conventions, not bundler config:
 
-- **Server-only:** `lib/pi.ts` (uses `node:crypto`, reads `process.env`, hits Podcast Index). Imported only by `app/api/search/route.ts` and `app/api/feed/route.ts`. Never import it from anything in `components/` or from `app/page.tsx`.
+- **Server-only:** `lib/pi.ts` (uses `node:crypto`, reads `process.env`, hits Podcast Index). Imported only by `app/api/search/route.ts` and `app/api/feed/route.ts`. Never import it from anything in `components/` or from `app/page.tsx`. The BoostBox proxy at `app/api/lightning/boostbox/route.ts` follows the same pattern — it reads `BOOSTBOX_URL` / `BOOSTBOX_API_KEY` and forwards to the upstream service so the API key never reaches the browser.
 - **Browser-only:** `lib/store.ts` (Zustand, `'use client'`), `lib/v4v/nwc.ts` / `webln.ts` / `lnaddr.ts`, `lib/nostr/`, `lib/storage.ts` — they all touch `window.*` or `localStorage`. SSR guards exist (`typeof window === 'undefined'`) but assume client context.
 - **Isomorphic:** `lib/types.ts` (pure types), `lib/v4v/boost.ts` (orchestration logic; pulled in by client code).
 
@@ -88,6 +88,7 @@ The "⚡ BOOST" button at the top-right of `EpisodeList`'s header opens the moda
 5. **TLV records:** boostagram JSON goes in record `7629169` (Podcasting 2.0 standard) — that's the only TLV we add for boost metadata. The `sender_id` field already lives inside the JSON; we deliberately do **not** also emit a separate `696969` sender record because that key collides with shared-node sub-account routing (e.g. getalby.com uses `customKey=696969 customValue=<sub-account>`). Per-recipient `customKey`/`customValue` from the value block IS attached to the keysend so payments to shared nodes route to the right sub-account. Keep the JSON shape compatible with Helipad / Fountain / Castamatic ingestion.
 6. **WebLN customRecords are plain JSON, not hex.** WebLN providers (Alby, Mutiny) hex-encode `customRecords` values internally before putting them on the wire. Pre-hexing here causes double-encoding and Helipad can't `JSON.parse` the boostagram. NWC's `pay_keysend` is the opposite — NIP-47 spec requires hex-encoded TLV values. See `tlvHexFor` (NWC) vs `recordsForKeysend` (WebLN) in `lib/v4v/boost.ts` — they look symmetric but the wire formats are genuinely different.
 7. **Note amount is intent, not actual.** `formatContent` and the `amount` tag use `boostagram.value_msat_total` (what the user clicked Send on), not the sum of successful legs. A user who boosts 100 sats and has one leg fail still posts "Boosted 100 sats" — the partial breakdown is visible in the modal and Helipad.
+8. **BoostBox is LNURL-only.** `lib/v4v/boostbox.ts` POSTs the metadata via the `/api/lightning/boostbox` proxy *before* `fetchLnInvoice`, then puts the returned `desc` (`rss::payment::boost <url>`) in the LUD-21 `comment` field. Keysend recipients are untouched — TLV `7629169` already carries the boostagram inline. Failure of the BoostBox call is non-fatal; the LNURL leg falls back to `boostagram.message` as the comment so the payment still goes through.
 
 ## Nostr publish shape
 
@@ -135,6 +136,7 @@ Everything else lives in `localStorage` on the device and is never sent server-s
 - `bmb:sender_name` — last "From" name typed into the boost modal (`storage.senderName`).
 - `bmb:npub` — sentinel for silent re-login on page load (`storage.npub`).
 - `bmb:favorites:<npub>` / `bmb:favorites:guest` — per-identity favorites cache (`storage.favorites.get(npub) / .set(npub, …)`).
+- `bmb:boosts:<npub>` / `bmb:boosts:guest` — local log of sent boosts (`storage.boosts`), capped at 200 newest-first. Each entry holds the boostagram intent + per-leg results, with the BoostBox URL on each LNURL leg and the published Nostr `noteId` patched in once `publishBoostNote` resolves. The Zustand `boostsTick` (`bumpBoosts()`) wakes up subscribers — `GlobalNostrFeed` mixes these into the relay-discovered notes and dedupes any whose `noteId` matches a returned note.
 
 If you add another persisted field, add a typed accessor to `lib/storage.ts` and follow the `bmb:*` prefix.
 

--- a/app/api/lightning/boostbox/route.ts
+++ b/app/api/lightning/boostbox/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from 'next/server';
+import { getErrorMessage } from '@/lib/util';
+
+// Server-side proxy for the BoostBox metadata service.
+// Defaults match the public reference instance so the integration works
+// out of the box; override via env to point at a self-hosted deployment.
+const BOOSTBOX_URL = process.env.BOOSTBOX_URL || 'https://tardbox.com';
+const BOOSTBOX_API_KEY = process.env.BOOSTBOX_API_KEY || 'v4v4me';
+
+export async function POST(req: Request) {
+  try {
+    const payload = await req.json();
+    const upstream = await fetch(`${BOOSTBOX_URL}/boost`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Api-Key': BOOSTBOX_API_KEY,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!upstream.ok) {
+      const detail = await upstream.text().catch(() => '');
+      return NextResponse.json(
+        { error: `BoostBox error: ${upstream.status}`, detail },
+        { status: upstream.status },
+      );
+    }
+
+    const data = await upstream.json();
+    return NextResponse.json(data);
+  } catch (e) {
+    return NextResponse.json(
+      { error: getErrorMessage(e, 'BoostBox proxy failed') },
+      { status: 500 },
+    );
+  }
+}

--- a/components/boost-card.tsx
+++ b/components/boost-card.tsx
@@ -1,0 +1,154 @@
+'use client';
+import { Fragment, type ReactNode } from 'react';
+import type { StoredBoost } from '@/lib/types';
+import { useApp } from '@/lib/store';
+import { shortNpub } from '@/lib/nostr';
+
+const LINK_RE = /(https?:\/\/[^\s]+)/gi;
+
+function splitTrailingPunct(token: string): { token: string; trailing: string } {
+  let trailing = '';
+  while (token.length > 0 && /[.,;:!?)\]]$/.test(token)) {
+    trailing = token.slice(-1) + trailing;
+    token = token.slice(0, -1);
+  }
+  return { token, trailing };
+}
+
+function linkify(text: string): ReactNode[] {
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  let m: RegExpExecArray | null;
+  LINK_RE.lastIndex = 0;
+  while ((m = LINK_RE.exec(text)) !== null) {
+    if (m.index > cursor) parts.push(text.slice(cursor, m.index));
+    const { token, trailing } = splitTrailingPunct(m[0]);
+    parts.push(
+      <a
+        key={`l-${m.index}`}
+        href={token}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-bolt break-all hover:underline underline-offset-2"
+      >
+        {token}
+      </a>,
+    );
+    if (trailing) parts.push(<Fragment key={`t-${m.index}`}>{trailing}</Fragment>);
+    cursor = m.index + m[0].length;
+  }
+  if (cursor < text.length) parts.push(text.slice(cursor));
+  return parts;
+}
+
+function timeAgo(unixMs: number): string {
+  const diff = (Date.now() - unixMs) / 1000;
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  if (diff < 86400 * 30) return `${Math.floor(diff / 86400)}d ago`;
+  return new Date(unixMs).toLocaleDateString();
+}
+
+function shortAddr(addr: string): string {
+  if (addr.includes('@')) return addr;
+  if (addr.length <= 14) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+}
+
+/**
+ * Renders one of the user's locally-saved sent boosts. Visual sibling to
+ * NoteCard so the global feed reads as a single boost stream when these are
+ * intermixed. Author identity comes from the active session's profile —
+ * the StoredBoost itself only carries a senderName fallback.
+ */
+export function BoostCard({ boost }: { boost: StoredBoost }) {
+  const identity = useApp((s) => s.identity);
+  const profile = identity?.profile;
+  const name =
+    boost.senderName ||
+    profile?.display_name?.trim() ||
+    profile?.name?.trim() ||
+    (identity ? shortNpub(identity.npub) : 'You');
+
+  const successLegs = boost.legs.filter((l) => l.ok);
+  const sats = successLegs.length
+    ? successLegs.reduce((s, l) => s + l.sats, 0)
+    : boost.sats;
+
+  return (
+    <article className="card p-3 flex gap-3 border-bolt/40">
+      {profile?.picture ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={profile.picture}
+          alt=""
+          className="w-9 h-9 rounded-full object-cover border border-bone/20 flex-shrink-0"
+        />
+      ) : (
+        <div className="w-9 h-9 rounded-full border border-bone/20 bg-line flex-shrink-0" />
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 flex-wrap text-xs">
+          <span className="font-display text-sm text-bone truncate">{name}</span>
+          <span className="text-muted">· {timeAgo(boost.ts)}</span>
+          <span className="stamp text-bolt border-bolt/60">⚡ {sats} sats</span>
+          <span className="stamp text-muted border-bone/20">sent</span>
+          {boost.noteId && (
+            <span className="text-muted">· also on Nostr</span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 mt-1.5 text-[11px] text-muted">
+          {boost.podcastImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={boost.podcastImage}
+              alt=""
+              className="w-4 h-4 object-cover border border-bone/20 flex-shrink-0"
+            />
+          ) : null}
+          <span className="truncate">
+            <span className="text-bolt">→</span>{' '}
+            <span className="text-bone">{boost.podcastTitle}</span>
+            {boost.episodeTitle ? (
+              <span className="text-muted"> · {boost.episodeTitle}</span>
+            ) : null}
+          </span>
+        </div>
+
+        {boost.message && (
+          <p className="text-sm text-bone whitespace-pre-wrap break-words mt-1.5">
+            {linkify(boost.message)}
+          </p>
+        )}
+
+        <ul className="mt-2 space-y-0.5 text-[11px] text-muted">
+          {boost.legs.map((leg, i) => (
+            <li key={i} className="flex items-center gap-2 flex-wrap">
+              <span className={leg.ok ? 'text-bolt' : 'text-red-400'}>
+                {leg.ok ? '✓' : '✗'}
+              </span>
+              <span className="text-bone">{leg.recipientName || shortAddr(leg.recipient)}</span>
+              <span>· {leg.sats} sats</span>
+              {leg.boostboxUrl && (
+                <a
+                  href={leg.boostboxUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-bolt hover:underline underline-offset-2"
+                  title="View metadata on BoostBox"
+                >
+                  📦 boostbox
+                </a>
+              )}
+              {leg.error && !leg.ok && (
+                <span className="text-red-400/80" title={leg.error}>· {leg.error}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </article>
+  );
+}

--- a/components/boost-modal/index.tsx
+++ b/components/boost-modal/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useEffect, useMemo, useState } from 'react';
 import confetti from 'canvas-confetti';
-import type { Episode, Podcast, Boostagram } from '@/lib/types';
+import type { Episode, Podcast, Boostagram, StoredBoost } from '@/lib/types';
 import { useApp } from '@/lib/store';
 import { sendBoost, splitSats, pickRail, type BoostResult, type Rail } from '@/lib/v4v/boost';
 import { publishBoostNote, resolvePublishRelays } from '@/lib/nostr';
@@ -36,6 +36,7 @@ interface Props {
 
 export function BoostModal({ episode, podcast, positionSec = 0, onClose }: Props) {
   const identity = useApp((s) => s.identity);
+  const bumpBoosts = useApp((s) => s.bumpBoosts);
   const [sats, setSats] = useState(500);
   const [msg, setMsg] = useState('');
   const [name, setName] = useState('');
@@ -120,6 +121,35 @@ export function BoostModal({ episode, podcast, positionSec = 0, onClose }: Props
       setRunning(false);
     }
 
+    // Persist the boost locally so the user's "view" surface (the global feed)
+    // can render it. Logged regardless of rail; the Nostr publish step below
+    // patches in `noteId` for dedupe against the relay-discovered version.
+    if (collected.some((r) => r.ok)) {
+      const stored: StoredBoost = {
+        uuid: boostagram.uuid!,
+        ts: Date.now(),
+        podcastTitle: podcast.title,
+        podcastId: podcast.id,
+        podcastGuid: podcast.podcastGuid,
+        podcastImage: episode?.image ?? podcast.image,
+        episodeTitle: episode?.title,
+        episodeGuid: episode?.guid,
+        sats,
+        message: msg || undefined,
+        senderName: name || undefined,
+        legs: collected.map((r) => ({
+          recipient: r.recipient.address,
+          recipientName: r.recipient.name,
+          sats: r.sats,
+          ok: r.ok,
+          error: r.error,
+          boostboxUrl: r.boostboxUrl,
+        })),
+      };
+      storage.boosts.add(identity?.npub, stored);
+      bumpBoosts();
+    }
+
     // Publish to nostr if signed in & opted in & at least one payment landed
     if (shareNostr && identity && collected.some((r) => r.ok)) {
       setPubState({ kind: 'publishing' });
@@ -132,6 +162,8 @@ export function BoostModal({ episode, podcast, positionSec = 0, onClose }: Props
           relays,
         });
         setPubState({ kind: 'done', note });
+        storage.boosts.update(identity.npub, boostagram.uuid!, { noteId: note.id });
+        bumpBoosts();
       } catch (e) {
         setPubState({ kind: 'error', message: getErrorMessage(e, 'publish failed') });
       }

--- a/components/feed-section.tsx
+++ b/components/feed-section.tsx
@@ -1,14 +1,14 @@
 'use client';
 import type { ReactNode } from 'react';
-import type { DiscoveredNote } from '@/lib/nostr';
 
 /**
  * Shared shell for the global + per-podcast Nostr feeds. Owns the
  * header / refresh-button / loading / error / empty / list state machine so
  * each surface only configures its title, description, empty message, and
- * the per-note renderer.
+ * the per-item renderer. Generic in the item type so the global feed can
+ * mix Nostr notes with locally-stored boosts.
  */
-export function FeedSection({
+export function FeedSection<T>({
   heading,
   description,
   notes,
@@ -17,16 +17,19 @@ export function FeedSection({
   emptyMessage,
   onRefresh,
   renderNote,
+  itemKey,
   className = '',
 }: {
   heading: ReactNode;
   description?: ReactNode;
-  notes: DiscoveredNote[] | null;
+  notes: T[] | null;
   loading: boolean;
   err: string | null;
   emptyMessage: string;
   onRefresh: () => void;
-  renderNote: (note: DiscoveredNote) => ReactNode;
+  renderNote: (item: T) => ReactNode;
+  /** Optional stable React key per item; defaults to array index. */
+  itemKey?: (item: T) => string;
   className?: string;
 }) {
   return (
@@ -51,7 +54,11 @@ export function FeedSection({
         <p className="text-sm text-muted">{emptyMessage}</p>
       )}
       {!err && notes !== null && notes.length > 0 && (
-        <div className="space-y-2">{notes.map(renderNote)}</div>
+        <div className="space-y-2">
+          {notes.map((item, i) => (
+            <div key={itemKey ? itemKey(item) : i}>{renderNote(item)}</div>
+          ))}
+        </div>
       )}
     </section>
   );

--- a/components/global-nostr-feed.tsx
+++ b/components/global-nostr-feed.tsx
@@ -1,14 +1,16 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   fetchAllPodcastNotes,
   useNostrFeed,
   type DiscoveredNote,
 } from '@/lib/nostr';
 import { storage } from '@/lib/storage';
-import type { Podcast } from '@/lib/types';
+import { useApp } from '@/lib/store';
+import type { Podcast, StoredBoost } from '@/lib/types';
 import { FeedSection } from './feed-section';
 import { NoteCard } from './nostr-note-card';
+import { BoostCard } from './boost-card';
 
 // In-memory mirror of storage.podcastMeta — avoids re-parsing localStorage on
 // every NoteCard render within the same page session.
@@ -41,11 +43,19 @@ async function resolvePodcast(guid: string): Promise<Podcast | null> {
   }
 }
 
+// Discriminated union of feed items. `ts` is unix ms across both kinds so
+// they sort cleanly. Notes use `createdAt * 1000`; stored boosts use the
+// timestamp captured when the user clicked Send.
+type FeedItem =
+  | { kind: 'note'; ts: number; key: string; note: DiscoveredNote }
+  | { kind: 'boost'; ts: number; key: string; boost: StoredBoost };
+
 /**
- * Global stream of every kind:1 note tagged with NIP-73 podcast identifiers,
- * across all podcasts and clients. Each note's `podcast:guid:` reference is
- * resolved against `/api/by-guid` so the show title + artwork render as
- * context.
+ * Global stream of every kind:1 note tagged with NIP-73 podcast identifiers
+ * across all podcasts and clients, **intermixed** with the user's own
+ * locally-saved sent boosts (BoostBox + keysend). When a sent boost has
+ * already been published to Nostr and discovered on the relays, the Nostr
+ * version wins (it carries author profile, replies, zap target).
  */
 export function GlobalNostrFeed() {
   const { notes, loading, err, refresh } = useNostrFeed({
@@ -53,6 +63,16 @@ export function GlobalNostrFeed() {
     fetcher: fetchAllPodcastNotes,
   });
   const [podcasts, setPodcasts] = useState<Record<string, Podcast | null>>({});
+  const identity = useApp((s) => s.identity);
+  const boostsTick = useApp((s) => s.boostsTick);
+
+  // Re-read the localStorage log whenever a boost is sent or the active
+  // identity changes. Per-npub key isolation is handled by storage.boosts.
+  const storedBoosts = useMemo<StoredBoost[]>(
+    () => storage.boosts.get(identity?.npub),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [identity?.npub, boostsTick],
+  );
 
   // Resolve podcast metadata for every unique guid that appears in `notes` —
   // covers both the SWR cache paint and every refresh.
@@ -69,8 +89,41 @@ export function GlobalNostrFeed() {
     }
   }, [notes, podcasts]);
 
+  const merged = useMemo<FeedItem[] | null>(() => {
+    if (notes === null) {
+      // Still surface the user's own log while the relay query is in flight.
+      if (storedBoosts.length === 0) return null;
+      return storedBoosts.map((b) => ({
+        kind: 'boost' as const,
+        ts: b.ts,
+        key: `boost:${b.uuid}`,
+        boost: b,
+      }));
+    }
+    const noteIds = new Set(notes.map((n) => n.id));
+    const items: FeedItem[] = notes.map((note) => ({
+      kind: 'note' as const,
+      ts: note.createdAt * 1000,
+      key: `note:${note.id}`,
+      note,
+    }));
+    for (const b of storedBoosts) {
+      // Dedupe: drop the local entry if its published note already came back
+      // from a relay — the discovered NoteCard is richer.
+      if (b.noteId && noteIds.has(b.noteId)) continue;
+      items.push({
+        kind: 'boost' as const,
+        ts: b.ts,
+        key: `boost:${b.uuid}`,
+        boost: b,
+      });
+    }
+    items.sort((a, b) => b.ts - a.ts);
+    return items;
+  }, [notes, storedBoosts]);
+
   return (
-    <FeedSection
+    <FeedSection<FeedItem>
       heading={
         <h2 className="font-display text-2xl">
           <span className="text-nostr">#</span> Global boost feed
@@ -80,21 +133,26 @@ export function GlobalNostrFeed() {
         <p className="text-xs text-muted mb-4">
           Every public Nostr post tagged with a Podcasting 2.0 <code>podcast:guid</code> identifier
           — boosts, comments, and chatter from any client following the convention (Fountain,
-          Wavlake, BoostMeBitch, etc.).
+          Wavlake, BoostMeBitch, etc.). Your own sends are intermixed locally, with BoostBox
+          metadata links where available.
         </p>
       }
-      notes={notes}
+      notes={merged}
       loading={loading}
       err={err}
       emptyMessage="no nostr activity surfaced from these relays yet."
       onRefresh={refresh}
-      renderNote={(n: DiscoveredNote) => (
-        <NoteCard
-          key={n.id}
-          note={n}
-          podcast={n.podcastGuid ? podcasts[n.podcastGuid] ?? null : null}
-        />
-      )}
+      itemKey={(item) => item.key}
+      renderNote={(item) =>
+        item.kind === 'note' ? (
+          <NoteCard
+            note={item.note}
+            podcast={item.note.podcastGuid ? podcasts[item.note.podcastGuid] ?? null : null}
+          />
+        ) : (
+          <BoostCard boost={item.boost} />
+        )
+      }
     />
   );
 }

--- a/components/global-nostr-feed.tsx
+++ b/components/global-nostr-feed.tsx
@@ -100,7 +100,6 @@ export function GlobalNostrFeed() {
         boost: b,
       }));
     }
-    const noteIds = new Set(notes.map((n) => n.id));
     const items: FeedItem[] = notes.map((note) => ({
       kind: 'note' as const,
       ts: note.createdAt * 1000,
@@ -108,9 +107,13 @@ export function GlobalNostrFeed() {
       note,
     }));
     for (const b of storedBoosts) {
-      // Dedupe: drop the local entry if its published note already came back
-      // from a relay — the discovered NoteCard is richer.
-      if (b.noteId && noteIds.has(b.noteId)) continue;
+      // Dedupe: once we've published the boost note, hide the local card.
+      // The user's NIP-65 write set may not intersect DEFAULT_RELAYS (used
+      // by fetchAllPodcastNotes), so we can't rely on the discovered set
+      // catching every published boost — but we'd rather risk a missing
+      // card than a permanent duplicate. Failed publishes leave noteId
+      // undefined and surface as locals indefinitely.
+      if (b.noteId) continue;
       items.push({
         kind: 'boost' as const,
         ts: b.ts,

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -5,7 +5,7 @@
 // raw key strings live in exactly one file and SSR/quota guards aren't
 // duplicated across components.
 
-import type { FavoritePodcast, Podcast } from './types';
+import type { FavoritePodcast, Podcast, StoredBoost } from './types';
 import type { DiscoveredNote } from './nostr';
 
 const KEYS = {
@@ -16,7 +16,10 @@ const KEYS = {
   favoritesPrefix: 'bmb:favorites',
   podcastMetaPrefix: 'bmb:pmeta',     // /api/by-guid result, keyed by guid
   feedNotesPrefix: 'bmb:feed',        // last DiscoveredNote[] per feed surface
+  boostsPrefix: 'bmb:boosts',         // sent-boost log, keyed by npub or 'guest'
 } as const;
+
+const BOOSTS_CAP = 200;
 
 const isBrowser = () => typeof window !== 'undefined';
 
@@ -37,6 +40,10 @@ function safeRemove(key: string) {
 
 function favKey(npub: string | null | undefined) {
   return `${KEYS.favoritesPrefix}:${npub ?? 'guest'}`;
+}
+
+function boostsKey(npub: string | null | undefined) {
+  return `${KEYS.boostsPrefix}:${npub ?? 'guest'}`;
 }
 
 // Generic time-bounded cache cell. `t` is the unix-ms write time; `v` is the
@@ -127,6 +134,44 @@ export const storage = {
       getTimed<DiscoveredNote[]>(`${KEYS.feedNotesPrefix}:${key}`, FEED_NOTES_TTL_MS),
     set: (key: string, v: DiscoveredNote[]) =>
       setTimed(`${KEYS.feedNotesPrefix}:${key}`, v),
+  },
+
+  /**
+   * Sent-boost log, namespaced by npub (`:guest` when signed out). Used by the
+   * "view your sends" surface that intermixes with the global Nostr feed.
+   * Capped at BOOSTS_CAP newest-first; oldest entries are dropped on overflow.
+   */
+  boosts: {
+    get: (npub: string | null | undefined): StoredBoost[] => {
+      const raw = safeGet(boostsKey(npub));
+      if (!raw) return [];
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? (parsed as StoredBoost[]) : [];
+      } catch {
+        return [];
+      }
+    },
+    set: (npub: string | null | undefined, list: StoredBoost[]) => {
+      const trimmed = list.slice(0, BOOSTS_CAP);
+      safeSet(boostsKey(npub), JSON.stringify(trimmed));
+    },
+    add: (npub: string | null | undefined, entry: StoredBoost) => {
+      const list = storage.boosts.get(npub);
+      storage.boosts.set(npub, [entry, ...list]);
+    },
+    update: (
+      npub: string | null | undefined,
+      uuid: string,
+      patch: Partial<StoredBoost>,
+    ) => {
+      const list = storage.boosts.get(npub);
+      const idx = list.findIndex((b) => b.uuid === uuid);
+      if (idx < 0) return;
+      const next = [...list];
+      next[idx] = { ...next[idx], ...patch };
+      storage.boosts.set(npub, next);
+    },
   },
 
   /** Favorites are namespaced by npub; signed-out users use `:guest`. */

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -22,6 +22,11 @@ interface AppState {
   addFavorite: (p: FavoritePodcast) => void;
   removeFavorite: (guid: string) => void;
   setFavorites: (next: Record<string, FavoritePodcast>) => void;
+
+  // Increments whenever a boost is written to localStorage so feed surfaces
+  // can re-derive without polling. Source of truth stays in storage.boosts.
+  boostsTick: number;
+  bumpBoosts: () => void;
 }
 
 export const useApp = create<AppState>((set, get) => ({
@@ -57,4 +62,7 @@ export const useApp = create<AppState>((set, get) => ({
     storage.favorites.set(s.identity?.npub, next);
     return { favorites: next };
   }),
+
+  boostsTick: 0,
+  bumpBoosts: () => set((s) => ({ boostsTick: s.boostsTick + 1 })),
 }));

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -74,6 +74,39 @@ export interface BoostResult {
   ok: boolean;
   preimage?: string;
   error?: string;
+  // Set on LNURL legs when BoostBox accepted the metadata. The URL is the
+  // public landing page; the id is the last path segment.
+  boostboxUrl?: string;
+  boostboxId?: string;
+}
+
+/**
+ * One sent boost, captured locally for the "My Boosts" panel. Indexed by uuid.
+ * Stored in `bmb:boosts:<npub>` (or `:guest` when signed out).
+ */
+export interface StoredBoost {
+  uuid: string;
+  ts: number;                  // unix ms — when the user confirmed
+  podcastTitle: string;
+  podcastId?: number;
+  podcastGuid?: string;
+  podcastImage?: string;
+  episodeTitle?: string;
+  episodeGuid?: string;
+  sats: number;                // intent total, in sats
+  message?: string;
+  senderName?: string;
+  noteId?: string;             // nostr event id of the boost note, if published
+  legs: StoredBoostLeg[];
+}
+
+export interface StoredBoostLeg {
+  recipient: string;           // node pubkey or lightning address
+  recipientName?: string;
+  sats: number;
+  ok: boolean;
+  error?: string;
+  boostboxUrl?: string;         // present on LNURL legs when BoostBox accepted
 }
 
 export interface FavoritePodcast {

--- a/lib/v4v/boost.ts
+++ b/lib/v4v/boost.ts
@@ -8,6 +8,7 @@ import type { Boostagram, ValueBlock, ValueRecipient, BoostResult } from '@/lib/
 import { hasNwc, nwcKeysend, nwcPayInvoice } from './nwc';
 import { hasWebln, weblnKeysend, weblnPayInvoice } from './webln';
 import { fetchLnInvoice } from './lnaddr';
+import { storeBoostMetadata } from './boostbox';
 
 // TLV custom record number for podcast boostagrams (Podcasting 2.0 spec).
 // The boostagram JSON already carries `sender_id`, so we don't add a separate
@@ -92,16 +93,32 @@ async function payOne(
 
   try {
     if (recipient.type === 'lnaddress') {
+      // LNURL invoices can't carry a TLV boostagram, so park the metadata
+      // in BoostBox and put its `desc` (containing the lookup URL) in the
+      // LUD-21 comment. Falls back to the plain message if BoostBox is
+      // unreachable or the recipient doesn't allow comments.
+      const stored = await storeBoostMetadata({
+        boostagram,
+        recipient,
+        splitWeight: recipient.split,
+        legMsat: sats * 1000,
+      });
       const invoice = await fetchLnInvoice({
         address: recipient.address,
         amount_msat: sats * 1000,
-        comment: boostagram.message,
+        comment: stored?.desc ?? boostagram.message,
       });
       const preimage =
         rail === 'nwc'
           ? await nwcPayInvoice(invoice)
           : await weblnPayInvoice(invoice);
-      return { ...base, ok: true, preimage };
+      return {
+        ...base,
+        ok: true,
+        preimage,
+        boostboxUrl: stored?.url,
+        boostboxId: stored?.url?.split('/').pop() || undefined,
+      };
     }
 
     // type === 'node' → keysend

--- a/lib/v4v/boost.ts
+++ b/lib/v4v/boost.ts
@@ -103,10 +103,17 @@ async function payOne(
         splitWeight: recipient.split,
         legMsat: sats * 1000,
       });
+      // Concat desc + user message so recipients without BoostBox-aware
+      // tooling still see the typed message. fetchLnInvoice truncates to
+      // commentAllowed if the combined string exceeds the recipient's cap.
+      const userMsg = boostagram.message?.trim() || undefined;
+      const comment = stored?.desc
+        ? userMsg ? `${stored.desc} — ${userMsg}` : stored.desc
+        : userMsg;
       const invoice = await fetchLnInvoice({
         address: recipient.address,
         amount_msat: sats * 1000,
-        comment: stored?.desc ?? boostagram.message,
+        comment,
       });
       const preimage =
         rail === 'nwc'

--- a/lib/v4v/boostbox.ts
+++ b/lib/v4v/boostbox.ts
@@ -8,6 +8,7 @@
 //
 // @see https://github.com/ChadFarrow/boostbox
 
+import { nip19 } from 'nostr-tools';
 import type { Boostagram, ValueRecipient } from '@/lib/types';
 
 interface BoostBoxResponse {
@@ -59,7 +60,7 @@ function buildPayload(
     app_version: boostagram.app_version,
     sender_name: boostagram.sender_name,
     sender_id: boostagram.sender_id,
-    sender_npub: boostagram.sender_id,
+    sender_npub: boostagram.sender_id ? nip19.npubEncode(boostagram.sender_id) : undefined,
     recipient_name: recipient.name,
     recipient_address: recipient.address,
     feed_guid: boostagram.remote_feed_guid,

--- a/lib/v4v/boostbox.ts
+++ b/lib/v4v/boostbox.ts
@@ -1,0 +1,102 @@
+// BoostBox client — stores Podcasting 2.0 boost metadata over HTTP and
+// returns a short `desc` string ("rss::payment::boost <url>") suitable for
+// the LUD-21 comment field on an LNURL invoice.
+//
+// Used only on the LNURL leg of the boost flow: keysend carries the same
+// metadata inline as TLV 7629169, so BoostBox is unnecessary there. Failure
+// is non-fatal — callers fall back to the user's plain-text message.
+//
+// @see https://github.com/ChadFarrow/boostbox
+
+import type { Boostagram, ValueRecipient } from '@/lib/types';
+
+interface BoostBoxResponse {
+  id: string;
+  url: string;
+  desc: string;
+}
+
+interface BoostBoxPayload {
+  action: 'boost' | 'stream';
+  split: number;
+  value_msat: number;
+  value_msat_total: number;
+  timestamp: string;
+  message?: string;
+  app_name?: string;
+  app_version?: string;
+  sender_name?: string;
+  sender_id?: string;
+  sender_npub?: string;
+  recipient_name?: string;
+  recipient_address?: string;
+  feed_guid?: string;
+  feed_title?: string;
+  item_guid?: string;
+  item_title?: string;
+  remote_feed_guid?: string;
+  remote_item_guid?: string;
+  group?: string;
+  boost_link?: string;
+}
+
+function buildPayload(
+  boostagram: Boostagram,
+  recipient: ValueRecipient,
+  splitWeight: number,
+  legMsat: number,
+): BoostBoxPayload {
+  const action: 'boost' | 'stream' =
+    boostagram.action === 'boost' ? 'boost' : 'stream';
+  return {
+    action,
+    split: splitWeight || 1,
+    value_msat: legMsat,
+    value_msat_total: boostagram.value_msat_total ?? legMsat,
+    timestamp: new Date().toISOString(),
+    message: boostagram.message,
+    app_name: boostagram.app_name,
+    app_version: boostagram.app_version,
+    sender_name: boostagram.sender_name,
+    sender_id: boostagram.sender_id,
+    sender_npub: boostagram.sender_id,
+    recipient_name: recipient.name,
+    recipient_address: recipient.address,
+    feed_guid: boostagram.remote_feed_guid,
+    feed_title: boostagram.podcast,
+    item_guid: boostagram.episode_guid ?? boostagram.remote_item_guid,
+    item_title: boostagram.episode,
+    remote_feed_guid: boostagram.remote_feed_guid,
+    remote_item_guid: boostagram.remote_item_guid,
+    group: boostagram.uuid,
+    boost_link: boostagram.url,
+  };
+}
+
+/**
+ * POST the boost metadata to the local BoostBox proxy and return the
+ * `desc` + `url` pair on success. Returns null on any failure so callers
+ * can degrade gracefully.
+ */
+export async function storeBoostMetadata(args: {
+  boostagram: Boostagram;
+  recipient: ValueRecipient;
+  splitWeight: number;
+  legMsat: number;
+}): Promise<{ desc: string; url: string } | null> {
+  try {
+    const res = await fetch('/api/lightning/boostbox', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(
+        buildPayload(args.boostagram, args.recipient, args.splitWeight, args.legMsat),
+      ),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as Partial<BoostBoxResponse>;
+    if (!data?.desc || !data?.url) return null;
+    return { desc: data.desc, url: data.url };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

LNURL recipients can't carry a TLV boostagram, so the metadata is now parked at a BoostBox instance (defaults to tardbox.com) and the returned `desc` (`rss::payment::boost https://tardbox.com/<id>`) rides in the LUD-21 `comment` field. Keysend recipients are unchanged — TLV `7629169` still carries the boostagram inline. BoostBox failure is non-fatal; the LNURL leg falls back to the plain message.

Sent boosts are persisted to `bmb:boosts:<npub>` (capped at 200) and intermixed with relay-discovered Nostr notes in the global feed, sorted by timestamp. When a published boost echoes back from a relay, the local entry dedupes against it via `noteId` so each boost shows up once.

## What changed

- **`app/api/lightning/boostbox/route.ts`** — server-only proxy that forwards to `${BOOSTBOX_URL}/boost` with `X-Api-Key`. Same boundary as `lib/pi.ts` so the API key never reaches the browser.
- **`lib/v4v/boostbox.ts`** — client `storeBoostMetadata({ boostagram, recipient, splitWeight, legMsat })`, returns `{ desc, url } | null`.
- **`lib/v4v/boost.ts`** — LNURL leg of `payOne` calls BoostBox first, uses `desc` as the comment, surfaces `boostboxUrl` / `boostboxId` on `BoostResult`.
- **`lib/storage.ts`** — new `storage.boosts` namespace (per-npub, `:guest` when signed out) with `get` / `set` / `add` / `update`.
- **`lib/store.ts`** — `boostsTick` + `bumpBoosts()` so feed surfaces re-derive without polling localStorage.
- **`components/boost-modal/index.tsx`** — persists a `StoredBoost` after every successful send and patches in `noteId` once the Nostr publish resolves.
- **`components/feed-section.tsx`** — generic in the item type so the same shell renders both `NoteCard` and the new `BoostCard`.
- **`components/boost-card.tsx`** — new card for locally-stored sends; podcast art, message, per-leg ✓/✗, and a "📦 boostbox" link out per LNURL leg.
- **`components/global-nostr-feed.tsx`** — merges relay-discovered notes with `storage.boosts.get(identity?.npub)`, dedupes by `noteId`, sorts desc by `ts`.
- **`.env.example` + `CLAUDE.md`** — document `BOOSTBOX_URL`, `BOOSTBOX_API_KEY`, the LNURL-only boundary, and the `bmb:boosts:<npub>` storage key.

## Setup (required)

Drop your real tardbox.com API key into `.env.local`:

```
BOOSTBOX_URL=https://tardbox.com
BOOSTBOX_API_KEY=<your tardbox key>
```

The committed default `BOOSTBOX_API_KEY=v4v4me` is just a placeholder — the public reference key won't work against tardbox.com.

## Test plan

- [ ] `npm run build` — clean (de-facto typecheck; build passed locally on this branch)
- [ ] `npm run dev`, find a podcast with a Lightning Address recipient (Wavlake feeds work), boost a small amount
- [ ] DevTools → Network: `POST /api/lightning/boostbox` returns `{ id, url, desc }`
- [ ] DevTools → Network: the LNURL callback's `comment` query param is `rss::payment::boost https://tardbox.com/<id>`
- [ ] DevTools → Application → localStorage: `bmb:boosts:<npub>` has the new entry with the per-leg `boostboxUrl`
- [ ] Global Nostr Feed renders the boost as a `BoostCard`, sorted by timestamp; after the relay echoes the published note back, the feed shows one card (the discovered note), not two
- [ ] Boost a keysend-only feed: stored locally, BoostBox proxy *not* called, card still appears in the feed
- [ ] Sign out / sign in with a different npub: lists are isolated per npub
- [ ] Open a `boostboxUrl` from a card: tardbox.com serves the HTML page with the same `x-rss-payment` JSON we stored

https://claude.ai/code/session_019eqg48Kww7CpNwHDVhKive