### PR TITLE
Add private boost option for logged-in Nostr users

### DIFF
--- a/components/boost-modal/index.tsx
+++ b/components/boost-modal/index.tsx
@@ -45,8 +45,13 @@ export function BoostModal({ episode, podcast, positionSec = 0, onClose }: Props
   const [running, setRunning] = useState(false);
   const [paymentDone, setPaymentDone] = useState(false);
 
-  const [shareNostr, setShareNostr] = useState(true);
+  const [shareNostr, setShareNostr] = useState(() => storage.shareNostr.get());
   const [pubState, setPubState] = useState<PublishState>({ kind: 'idle' });
+
+  function handleShareNostrChange(v: boolean) {
+    setShareNostr(v);
+    storage.shareNostr.set(v);
+  }
 
   const relays = useMemo(() => resolvePublishRelays(identity), [identity]);
   const relaySource: RelaySource =
@@ -166,7 +171,7 @@ export function BoostModal({ episode, podcast, positionSec = 0, onClose }: Props
           <SenderName value={name} onChange={setName} identity={identity} />
           <NostrShareToggle
             checked={shareNostr}
-            onChange={setShareNostr}
+            onChange={handleShareNostrChange}
             identity={identity}
             relayCount={relays.length}
             relaySource={relaySource}

--- a/components/boost-modal/nostr-share-toggle.tsx
+++ b/components/boost-modal/nostr-share-toggle.tsx
@@ -31,20 +31,24 @@ export function NostrShareToggle({
       />
       <div className="flex-1 text-xs">
         <div className="text-bone flex items-center gap-2">
-          <span className="text-nostr">◆</span>
-          Share boost on Nostr
+          <span className={checked && identity ? 'text-nostr' : 'text-muted'}>◆</span>
+          {identity && !checked ? 'Private boost — Lightning only' : 'Share boost on Nostr'}
         </div>
         <div className="text-muted mt-0.5 leading-relaxed">
           {identity ? (
-            <>
-              Publishes a kind:1 note tagged with NIP-73 podcast refs to {relayCount} relays.
-              {relaySource === 'nip65' && (
-                <span className="text-nostr/80"> · using your NIP-65 list</span>
-              )}
-              {relaySource === 'default' && (
-                <span className="text-muted/70"> · using defaults (no NIP-65 found)</span>
-              )}
-            </>
+            checked ? (
+              <>
+                Publishes a kind:1 note tagged with NIP-73 podcast refs to {relayCount} relays.
+                {relaySource === 'nip65' && (
+                  <span className="text-nostr/80"> · using your NIP-65 list</span>
+                )}
+                {relaySource === 'default' && (
+                  <span className="text-muted/70"> · using defaults (no NIP-65 found)</span>
+                )}
+              </>
+            ) : (
+              'No Nostr note will be published. Only the Lightning payment goes out.'
+            )
           ) : (
             'Sign in with Nostr to enable.'
           )}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -13,6 +13,7 @@ const KEYS = {
   nwcUri: 'bmb:nwc_uri',
   relays: 'bmb:relays',
   senderName: 'bmb:sender_name',
+  shareNostr: 'bmb:share_nostr',
   favoritesPrefix: 'bmb:favorites',
   podcastMetaPrefix: 'bmb:pmeta',     // /api/by-guid result, keyed by guid
   feedNotesPrefix: 'bmb:feed',        // last DiscoveredNote[] per feed surface
@@ -102,6 +103,16 @@ export const storage = {
   senderName: {
     get: () => safeGet(KEYS.senderName),
     set: (v: string) => safeSet(KEYS.senderName, v),
+  },
+
+  /**
+   * Whether the boost modal defaults to publishing a Nostr note. Unset = true
+   * (existing behavior); user can flip to false to make every boost private
+   * (Lightning only) until they re-enable it.
+   */
+  shareNostr: {
+    get: (): boolean => safeGet(KEYS.shareNostr) !== '0',
+    set: (v: boolean) => safeSet(KEYS.shareNostr, v ? '1' : '0'),
   },
 
   /**


### PR DESCRIPTION
Boost modal already had a "Share boost on Nostr" toggle, but the
unchecked state wasn't framed as a private boost and the choice
reset every time the modal opened. Now:

- The toggle reframes itself as "Private boost — Lightning only"
  when unchecked, with copy explaining no Nostr note is published.
- The user's preference persists via storage.shareNostr
  (bmb:share_nostr in localStorage), so opting into private boosts
  sticks across modal opens until flipped back.

https://claude.ai/code/session_01CvFdMCqwq9cHKvouQSWMfX