### PR TITLE
Cache feed-author kind:0 + NIP-65 fallback for missing profiles

### DIFF
--- a/lib/nostr/discover.ts
+++ b/lib/nostr/discover.ts
@@ -1,6 +1,7 @@
 import { nip19, type Event } from 'nostr-tools';
 import { withPool } from './pool';
 import { DEFAULT_RELAYS } from './relays';
+import { storage } from '../storage';
 import type { ProfileMetadata } from './auth';
 
 export interface DiscoveredNote {
@@ -293,28 +294,17 @@ async function fetchQuotedEvents(
   return out;
 }
 
-async function fetchProfiles(
-  pool: import('nostr-tools').SimplePool,
-  relays: string[],
-  authors: string[],
-): Promise<Map<string, ProfileMetadata>> {
-  const out = new Map<string, ProfileMetadata>();
-  if (!authors.length) return out;
-  let events: Event[] = [];
-  try {
-    events = await pool.querySync(relays, {
-      kinds: [0],
-      authors,
-    });
-  } catch {
-    return out;
-  }
-  // Newest kind:0 wins per pubkey.
+// Reduce a list of kind:0 events to "newest per pubkey, parsed". Skips events
+// whose content isn't valid JSON.
+function newestProfilesByAuthor(
+  events: Event[],
+): Map<string, ProfileMetadata> {
   const newest = new Map<string, Event>();
   for (const e of events) {
     const prev = newest.get(e.pubkey);
     if (!prev || e.created_at > prev.created_at) newest.set(e.pubkey, e);
   }
+  const out = new Map<string, ProfileMetadata>();
   for (const [pubkey, e] of newest) {
     try {
       out.set(pubkey, JSON.parse(e.content) as ProfileMetadata);
@@ -322,5 +312,125 @@ async function fetchProfiles(
       // ignore unparseable content
     }
   }
+  return out;
+}
+
+// Pull NIP-65 (kind:10002) for the given authors and return the union of
+// their write-marked / unmarked relay URLs. Used as a fallback hint set when
+// the default-relay batch couldn't find a profile — the author may publish
+// their kind:0 only to their personal write relays.
+async function fetchAuthorWriteRelays(
+  pool: import('nostr-tools').SimplePool,
+  relays: string[],
+  authors: string[],
+): Promise<string[]> {
+  let events: Event[] = [];
+  try {
+    events = await pool.querySync(relays, {
+      kinds: [10002],
+      authors,
+    });
+  } catch {
+    return [];
+  }
+  const newest = new Map<string, Event>();
+  for (const e of events) {
+    const prev = newest.get(e.pubkey);
+    if (!prev || e.created_at > prev.created_at) newest.set(e.pubkey, e);
+  }
+  const urls = new Set<string>();
+  for (const e of newest.values()) {
+    for (const tag of e.tags) {
+      if (tag[0] !== 'r' || !tag[1]) continue;
+      const url = tag[1].trim().replace(/\/$/, '');
+      if (!url || !url.startsWith('wss://')) continue;
+      const marker = tag[2];
+      if (!marker || marker === 'write') urls.add(url);
+    }
+  }
+  return Array.from(urls);
+}
+
+async function fetchProfiles(
+  pool: import('nostr-tools').SimplePool,
+  relays: string[],
+  authors: string[],
+): Promise<Map<string, ProfileMetadata>> {
+  const out = new Map<string, ProfileMetadata>();
+  if (!authors.length) return out;
+
+  // 1. Serve from per-pubkey localStorage cache where possible. `null` means
+  //    "we recently looked and they have no kind:0" — skip the fetch.
+  //    `undefined` means stale or never cached — fetch.
+  const toFetch: string[] = [];
+  for (const pubkey of authors) {
+    const cached = storage.profile.get(pubkey);
+    if (cached === undefined) toFetch.push(pubkey);
+    else if (cached !== null) out.set(pubkey, cached);
+  }
+  if (!toFetch.length) return out;
+
+  // 2. First pass: batch-query the standard relay set.
+  let firstPassOk = false;
+  let events: Event[] = [];
+  try {
+    events = await pool.querySync(relays, {
+      kinds: [0],
+      authors: toFetch,
+    });
+    firstPassOk = true;
+  } catch {
+    // swallow — fall through to NIP-65 pass below
+  }
+  for (const [pubkey, profile] of newestProfilesByAuthor(events)) {
+    out.set(pubkey, profile);
+    storage.profile.set(pubkey, profile);
+  }
+
+  // 3. NIP-65 fallback: for any author still missing, look up their write
+  //    relays via kind:10002 and re-query kind:0 against the union. Cap the
+  //    extra relay set so latency stays bounded.
+  const missing = toFetch.filter((p) => !out.has(p));
+  let fallbackRan = false;
+  if (missing.length) {
+    const extras = await fetchAuthorWriteRelays(pool, relays, missing);
+    const fallbackRelays = Array.from(new Set([...relays, ...extras])).slice(0, 12);
+    const opened = fallbackRelays.filter((r) => !relays.includes(r));
+    if (opened.length) {
+      try {
+        let fbEvents: Event[] = [];
+        try {
+          fbEvents = await pool.querySync(fallbackRelays, {
+            kinds: [0],
+            authors: missing,
+          });
+          fallbackRan = true;
+        } catch {
+          // ignore — leave still-missing authors for negative caching below
+        }
+        for (const [pubkey, profile] of newestProfilesByAuthor(fbEvents)) {
+          out.set(pubkey, profile);
+          storage.profile.set(pubkey, profile);
+        }
+      } finally {
+        try {
+          pool.close(opened);
+        } catch {
+          // ignore close errors
+        }
+      }
+    }
+  }
+
+  // 4. Negative-cache anything still missing so a returning visitor doesn't
+  //    re-issue the same lookups within the miss-TTL. Only do this when at
+  //    least one pass actually completed — if both threw we genuinely don't
+  //    know whether the profile exists.
+  if (firstPassOk || fallbackRan) {
+    for (const p of toFetch) {
+      if (!out.has(p)) storage.profile.setMiss(p);
+    }
+  }
+
   return out;
 }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -6,7 +6,7 @@
 // duplicated across components.
 
 import type { FavoritePodcast, Podcast, StoredBoost } from './types';
-import type { DiscoveredNote } from './nostr';
+import type { DiscoveredNote, ProfileMetadata } from './nostr';
 
 const KEYS = {
   npub: 'bmb:npub',
@@ -18,6 +18,7 @@ const KEYS = {
   podcastMetaPrefix: 'bmb:pmeta',     // /api/by-guid result, keyed by guid
   feedNotesPrefix: 'bmb:feed',        // last DiscoveredNote[] per feed surface
   boostsPrefix: 'bmb:boosts',         // sent-boost log, keyed by npub or 'guest'
+  profilePrefix: 'bmb:profile',       // kind:0 metadata, keyed by pubkey (hex)
 } as const;
 
 const BOOSTS_CAP = 200;
@@ -73,6 +74,8 @@ function setTimed<T>(key: string, value: T) {
 
 const PODCAST_META_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const FEED_NOTES_TTL_MS = 5 * 60 * 1000;             // 5 minutes
+const PROFILE_TTL_MS = 7 * 24 * 60 * 60 * 1000;      // 7 days for found profiles
+const PROFILE_MISS_TTL_MS = 60 * 60 * 1000;          // 1 hour for known-missing
 
 export const storage = {
   npub: {
@@ -182,6 +185,36 @@ export const storage = {
       next[idx] = { ...next[idx], ...patch };
       storage.boosts.set(npub, next);
     },
+  },
+
+  /**
+   * Per-pubkey kind:0 cache shared across every feed surface. Stores both
+   * found profiles (7-day TTL) and known-missing pubkeys (1-hour negative TTL)
+   * so we don't hammer relays for authors who haven't published metadata.
+   *
+   * `get` is tri-state:
+   *   - ProfileMetadata → fresh hit, use it
+   *   - null            → fresh negative hit, skip the network
+   *   - undefined       → stale or never cached, caller should fetch
+   */
+  profile: {
+    get: (pubkey: string): ProfileMetadata | null | undefined => {
+      const raw = safeGet(`${KEYS.profilePrefix}:${pubkey}`);
+      if (!raw) return undefined;
+      try {
+        const cell = JSON.parse(raw) as CacheCell<ProfileMetadata | null>;
+        if (!cell || typeof cell.t !== 'number') return undefined;
+        const ttl = cell.v === null ? PROFILE_MISS_TTL_MS : PROFILE_TTL_MS;
+        if (Date.now() - cell.t > ttl) return undefined;
+        return cell.v;
+      } catch {
+        return undefined;
+      }
+    },
+    set: (pubkey: string, v: ProfileMetadata) =>
+      setTimed(`${KEYS.profilePrefix}:${pubkey}`, v),
+    setMiss: (pubkey: string) =>
+      setTimed<ProfileMetadata | null>(`${KEYS.profilePrefix}:${pubkey}`, null),
   },
 
   /** Favorites are namespaced by npub; signed-out users use `:guest`. */


### PR DESCRIPTION
Two fixes for bare-npub rows in the global Nostr feed:

1. Per-pubkey profile cache in storage (`bmb:profile:<hex>`). 7-day
   TTL for found profiles, 1-hour negative TTL for known-missing —
   so a returning visitor doesn't re-issue the same kind:0 lookups
   on every refresh, and we don't hammer relays for authors who
   haven't published metadata yet.

2. NIP-65 fallback in `fetchProfiles`. After the default-relay
   batch, any author still missing gets a kind:10002 lookup, and
   we re-query kind:0 against the union of default + their write
   relays (capped at 12 total). This catches authors whose profile
   only lives on their personal relay set.

Also splits the silent-fail path: only negative-cache when at
least one query actually completed, so a transient network failure
doesn't poison the cache.