### PR TITLE
Add purplepag.es to kind:0 / kind:10002 lookups

### DIFF
--- a/lib/nostr/discover.ts
+++ b/lib/nostr/discover.ts
@@ -1,6 +1,6 @@
 import { nip19, type Event } from 'nostr-tools';
 import { withPool } from './pool';
-import { DEFAULT_RELAYS } from './relays';
+import { DEFAULT_RELAYS, PROFILE_RELAYS } from './relays';
 import { storage } from '../storage';
 import type { ProfileMetadata } from './auth';
 
@@ -318,20 +318,32 @@ function newestProfilesByAuthor(
 // Pull NIP-65 (kind:10002) for the given authors and return the union of
 // their write-marked / unmarked relay URLs. Used as a fallback hint set when
 // the default-relay batch couldn't find a profile — the author may publish
-// their kind:0 only to their personal write relays.
+// their kind:0 only to their personal write relays. Queries the union of
+// the caller's relays + PROFILE_RELAYS so authors whose NIP-65 only lives
+// on purplepag.es still get resolved.
 async function fetchAuthorWriteRelays(
   pool: import('nostr-tools').SimplePool,
   relays: string[],
   authors: string[],
 ): Promise<string[]> {
+  const queryRelays = Array.from(new Set([...relays, ...PROFILE_RELAYS]));
+  const opened = queryRelays.filter((r) => !relays.includes(r));
   let events: Event[] = [];
   try {
-    events = await pool.querySync(relays, {
+    events = await pool.querySync(queryRelays, {
       kinds: [10002],
       authors,
     });
   } catch {
     return [];
+  } finally {
+    if (opened.length) {
+      try {
+        pool.close(opened);
+      } catch {
+        // ignore close errors
+      }
+    }
   }
   const newest = new Map<string, Event>();
   for (const e of events) {
@@ -370,17 +382,30 @@ async function fetchProfiles(
   }
   if (!toFetch.length) return out;
 
-  // 2. First pass: batch-query the standard relay set.
+  // 2. First pass: batch-query the standard relay set unioned with the
+  //    profile-outbox relays (purplepag.es etc.). The outbox relays exist
+  //    specifically to host kind:0 for arbitrary authors, so this catches
+  //    the common case where an author's profile isn't on DEFAULT_RELAYS.
+  const firstPassRelays = Array.from(new Set([...relays, ...PROFILE_RELAYS]));
+  const firstPassExtras = firstPassRelays.filter((r) => !relays.includes(r));
   let firstPassOk = false;
   let events: Event[] = [];
   try {
-    events = await pool.querySync(relays, {
+    events = await pool.querySync(firstPassRelays, {
       kinds: [0],
       authors: toFetch,
     });
     firstPassOk = true;
   } catch {
     // swallow — fall through to NIP-65 pass below
+  } finally {
+    if (firstPassExtras.length) {
+      try {
+        pool.close(firstPassExtras);
+      } catch {
+        // ignore close errors
+      }
+    }
   }
   for (const [pubkey, profile] of newestProfilesByAuthor(events)) {
     out.set(pubkey, profile);

--- a/lib/nostr/profile.ts
+++ b/lib/nostr/profile.ts
@@ -1,14 +1,16 @@
 import { withPool } from './pool';
-import { DEFAULT_RELAYS } from './relays';
+import { DEFAULT_RELAYS, PROFILE_RELAYS } from './relays';
 import type { ProfileMetadata } from './auth';
 
 // Fetch the user's kind:0 metadata event from the given relays (defaults to
-// our standard set). Returns null if no event is found or parsing fails.
+// our standard set unioned with the profile-outbox relays). Returns null if
+// no event is found or parsing fails.
 export async function fetchProfile(
   pubkey: string,
   relays?: string[],
 ): Promise<ProfileMetadata | null> {
-  const useRelays = relays ?? DEFAULT_RELAYS;
+  const base = relays ?? DEFAULT_RELAYS;
+  const useRelays = Array.from(new Set([...base, ...PROFILE_RELAYS]));
   return withPool(useRelays, async (pool) => {
     try {
       const events = await pool.querySync(useRelays, {

--- a/lib/nostr/relays.ts
+++ b/lib/nostr/relays.ts
@@ -10,6 +10,16 @@ export const DEFAULT_RELAYS = [
   'wss://relay.fountain.fm',
 ];
 
+// Dedicated outbox relays for kind:0 (profile metadata) and kind:10002
+// (NIP-65 relay lists). purplepag.es is the de facto standard profile
+// outbox used by Damus, Amethyst, etc. — authors whose primary relays
+// don't intersect DEFAULT_RELAYS still tend to have their kind:0 mirrored
+// here. Always unioned into kind:0 / kind:10002 lookups so the global
+// feed can render display names + avatars for arbitrary authors.
+export const PROFILE_RELAYS = [
+  'wss://purplepag.es',
+];
+
 // NIP-65 relay list (kind:10002). We only consume the write side — we never
 // read events from arbitrary relays based on someone's read list, so the
 // parser drops it.

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -18,7 +18,7 @@ const KEYS = {
   podcastMetaPrefix: 'bmb:pmeta',     // /api/by-guid result, keyed by guid
   feedNotesPrefix: 'bmb:feed',        // last DiscoveredNote[] per feed surface
   boostsPrefix: 'bmb:boosts',         // sent-boost log, keyed by npub or 'guest'
-  profilePrefix: 'bmb:profile',       // kind:0 metadata, keyed by pubkey (hex)
+  profilePrefix: 'bmb:profile2',      // kind:0 metadata, keyed by pubkey (hex). Bumped from `:profile` to wipe stale negative-cache entries from before purplepag.es was added to the lookup path.
 } as const;
 
 const BOOSTS_CAP = 200;


### PR DESCRIPTION
PR #24's NIP-65 fallback only helps when an author's kind:10002 itself
lives on DEFAULT_RELAYS. For authors whose profile + relay-list both
live elsewhere (e.g. Chris Fisher / npub1p0kld…), every lookup missed
and got negative-cached for an hour, so the global feed kept rendering
bare npubs with blank avatars.

Add PROFILE_RELAYS = ['wss://purplepag.es']  the de facto outbox relay
used by Damus / Amethyst for kind:0 + kind:10002  and union it into:

  - fetchProfiles first pass (batch kind:0 lookup for feed authors)
  - fetchAuthorWriteRelays (NIP-65 fallback)
  - fetchProfile (single profile lookup at login)

Bump the storage prefix from `bmb:profile` to `bmb:profile2` so stale
negative-cache entries left over from before this fix don't keep the
old nulls alive for an hour after the new lookup path lands.