### PR TITLE
Show reply threads inline and persist repost state on Nostr feeds

### DIFF
--- a/components/global-nostr-feed.tsx
+++ b/components/global-nostr-feed.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   fetchAllPodcastNotes,
   useNostrFeed,
+  useViewerReposts,
   type DiscoveredNote,
 } from '@/lib/nostr';
 import { piMaybeUp, resolvePodcastByGuid } from '@/lib/podcast-meta';
@@ -47,6 +48,7 @@ export function GlobalNostrFeed() {
   const attempted = useRef<Set<string>>(new Set());
   const identity = useApp((s) => s.identity);
   const boostsTick = useApp((s) => s.boostsTick);
+  const repostedIds = useViewerReposts(notes, identity);
 
   // Re-read the localStorage log whenever a boost is sent or the active
   // identity changes. Per-npub key isolation is handled by storage.boosts.
@@ -146,6 +148,7 @@ export function GlobalNostrFeed() {
           <NoteCard
             note={item.note}
             podcast={item.note.podcastGuid ? podcasts[item.note.podcastGuid] ?? null : null}
+            repostedIds={repostedIds}
           />
         ) : (
           <BoostCard boost={item.boost} />

--- a/components/nostr-note-card.tsx
+++ b/components/nostr-note-card.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Fragment, useState, type ReactNode } from 'react';
+import { Fragment, useEffect, useState, type ReactNode } from 'react';
 import {
   resolvePublishRelays,
   shortNpub,
@@ -83,13 +83,19 @@ type ActionState = 'idle' | 'busy' | 'done' | 'error';
  * `podcast` is the show this note references — if provided, a small
  * "→ podcast title" line renders under the author header. The per-podcast
  * feed leaves it out since every card on that surface is about the same show.
+ *
+ * `repostedIds` is the set of note ids the signed-in viewer has previously
+ * reposted (kind:6 events) — used to seed the repost button into its "done"
+ * state across reloads. The same set is threaded down through nested replies.
  */
 export function NoteCard({
   note,
   podcast,
+  repostedIds,
 }: {
   note: DiscoveredNote;
   podcast?: Podcast | null;
+  repostedIds?: Set<string>;
 }) {
   const identity = useApp((s) => s.identity);
   const name =
@@ -106,8 +112,18 @@ export function NoteCard({
   const [composerState, setComposerState] = useState<ActionState>('idle');
   const [composerErr, setComposerErr] = useState<string | null>(null);
 
-  const [repostState, setRepostState] = useState<ActionState>('idle');
+  const alreadyReposted = repostedIds?.has(note.id) ?? false;
+  const [repostState, setRepostState] = useState<ActionState>(
+    alreadyReposted ? 'done' : 'idle',
+  );
   const [repostErr, setRepostErr] = useState<string | null>(null);
+
+  // Promote idle → done if the persisted set arrives after mount (login race
+  // or async useViewerReposts resolution). Don't downgrade — once the user has
+  // pressed repost in this session we always show 'done'.
+  useEffect(() => {
+    if (alreadyReposted && repostState === 'idle') setRepostState('done');
+  }, [alreadyReposted, repostState]);
 
   const [zapOpen, setZapOpen] = useState(false);
 
@@ -168,6 +184,7 @@ export function NoteCard({
   }
 
   return (
+    <div>
     <article className="card p-3 flex gap-3">
       <Avatar
         pubkey={note.pubkey}
@@ -232,9 +249,13 @@ export function NoteCard({
               <button
                 onClick={onRepost}
                 disabled={repostState === 'busy' || repostState === 'done'}
-                className="text-muted hover:text-nostr disabled:opacity-60"
+                className={
+                  repostState === 'done'
+                    ? 'text-nostr disabled:opacity-100'
+                    : 'text-muted hover:text-nostr disabled:opacity-60'
+                }
                 aria-label="Repost"
-                title="Repost"
+                title={repostState === 'done' ? 'Already reposted' : 'Repost'}
               >
                 {repostState === 'done' ? '🔁 reposted' : repostState === 'busy' ? '🔁 …' : '🔁 repost'}
               </button>
@@ -319,6 +340,14 @@ export function NoteCard({
         )}
       </div>
     </article>
+    {note.replies.length > 0 && (
+      <div className="mt-3 ml-6 pl-3 border-l-2 border-nostr/30 space-y-3">
+        {note.replies.map((r) => (
+          <NoteCard key={r.id} note={r} repostedIds={repostedIds} />
+        ))}
+      </div>
+    )}
+    </div>
   );
 }
 

--- a/components/podcast-nostr-feed.tsx
+++ b/components/podcast-nostr-feed.tsx
@@ -1,5 +1,11 @@
 'use client';
-import { fetchPodcastNotes, useNostrFeed, type DiscoveredNote } from '@/lib/nostr';
+import {
+  fetchPodcastNotes,
+  useNostrFeed,
+  useViewerReposts,
+  type DiscoveredNote,
+} from '@/lib/nostr';
+import { useApp } from '@/lib/store';
 import { FeedSection } from './feed-section';
 import { NoteCard } from './nostr-note-card';
 
@@ -21,6 +27,8 @@ export function PodcastNostrFeed({
     fetcher: () => fetchPodcastNotes(podcastGuid),
     deps: [podcastGuid],
   });
+  const identity = useApp((s) => s.identity);
+  const repostedIds = useViewerReposts(notes, identity);
 
   return (
     <FeedSection
@@ -36,7 +44,9 @@ export function PodcastNostrFeed({
       err={err}
       emptyMessage="no nostr notes tagged this podcast yet — be the first to boost."
       onRefresh={refresh}
-      renderNote={(n: DiscoveredNote) => <NoteCard key={n.id} note={n} />}
+      renderNote={(n: DiscoveredNote) => (
+        <NoteCard key={n.id} note={n} repostedIds={repostedIds} />
+      )}
     />
   );
 }

--- a/lib/nostr/discover.ts
+++ b/lib/nostr/discover.ts
@@ -18,6 +18,36 @@ export interface DiscoveredNote {
   episodeGuids: string[];  // any podcast:item:guid: refs on the note
   author: ProfileMetadata | null;
   rawEvent: Event;         // signed source event — needed to thread replies and to embed in NIP-18 reposts
+  replies: DiscoveredNote[]; // direct replies (NIP-10), oldest-first; recursive
+}
+
+// Defensive caps so a single noisy thread can't blow up the relay query budget.
+const MAX_THREAD_DEPTH = 6;
+const MAX_REPLIES_PER_THREAD = 200;
+const REPLY_QUERY_LIMIT = 500;
+
+/**
+ * Resolve the direct parent event id for a kind:1 reply per NIP-10:
+ *  - `mention` markers are ignored.
+ *  - If any e-tag has marker `reply`, that's the parent.
+ *  - Else if any e-tag has marker `root`, that's the parent (direct reply to root).
+ *  - Else (legacy positional), the last unmarked e-tag is the parent.
+ *  - Returns null when the event has no e-tag — i.e. it's top-level.
+ */
+function getParentEventId(e: Event): string | null {
+  const eTags = e.tags.filter(
+    (t) =>
+      t[0] === 'e' &&
+      typeof t[1] === 'string' &&
+      t[1].length === 64 &&
+      t[3] !== 'mention',
+  );
+  if (eTags.length === 0) return null;
+  const replyTag = eTags.find((t) => t[3] === 'reply');
+  if (replyTag) return replyTag[1];
+  const rootTag = eTags.find((t) => t[3] === 'root');
+  if (rootTag) return rootTag[1];
+  return eTags[eTags.length - 1][1];
 }
 
 interface FetchOpts {
@@ -108,6 +138,7 @@ function buildNote(
   relays: string[],
   profile: ProfileMetadata | null,
   quoted: Map<string, Event>,
+  replies: DiscoveredNote[] = [],
 ): DiscoveredNote {
   const amountTag = e.tags.find((t) => t[0] === 'amount')?.[1];
   let amountMsat: number | null = amountTag ? Number(amountTag) : null;
@@ -168,6 +199,7 @@ function buildNote(
     episodeGuids,
     author: profile,
     rawEvent: e,
+    replies,
   };
 }
 
@@ -233,22 +265,136 @@ async function assembleNotes(
 ): Promise<DiscoveredNote[]> {
   if (!events.length) return [];
 
-  // Dedupe by id (relays often return overlapping copies) and sort newest first.
+  // Dedupe by id (relays often return overlapping copies).
   const byId = new Map<string, Event>();
   for (const e of events) byId.set(e.id, e);
-  const unique = Array.from(byId.values()).sort(
-    (a, b) => b.created_at - a.created_at,
+  const uniqueEvents = Array.from(byId.values());
+
+  // Split into top-level (no e-tag) and reply candidates. publishReply()
+  // inherits the parent's NIP-73 i/k tags, so replies authored by this app
+  // arrive on the same `#i: podcast:guid:` query as their parent boost — we
+  // pull them out of the top-level list here so they only render nested.
+  const topLevelEvents: Event[] = [];
+  const seedReplies: Event[] = [];
+  for (const e of uniqueEvents) {
+    if (getParentEventId(e) === null) topLevelEvents.push(e);
+    else seedReplies.push(e);
+  }
+  topLevelEvents.sort((a, b) => b.created_at - a.created_at);
+
+  const childrenByParent = await fetchReplyTree(
+    pool,
+    relays,
+    topLevelEvents.map((e) => e.id),
+    seedReplies,
   );
 
-  const authors = Array.from(new Set(unique.map((e) => e.pubkey)));
+  // Flatten the entire tree so profile + quoted resolution covers every
+  // author once, not N+1.
+  const allTreeEvents: Event[] = [...topLevelEvents];
+  function collectChildren(parentId: string): void {
+    const children = childrenByParent.get(parentId);
+    if (!children) return;
+    for (const c of children) {
+      allTreeEvents.push(c);
+      collectChildren(c.id);
+    }
+  }
+  for (const e of topLevelEvents) collectChildren(e.id);
+
+  const authors = Array.from(new Set(allTreeEvents.map((e) => e.pubkey)));
   const [profiles, quoted] = await Promise.all([
     fetchProfiles(pool, relays, authors),
-    fetchQuotedEvents(pool, relays, unique),
+    fetchQuotedEvents(pool, relays, allTreeEvents),
   ]);
 
-  return unique.map((e) =>
-    buildNote(e, relays, profiles.get(e.pubkey) ?? null, quoted),
-  );
+  function build(e: Event): DiscoveredNote {
+    const children = childrenByParent.get(e.id) ?? [];
+    const replies = [...children]
+      .sort((a, b) => a.created_at - b.created_at)
+      .map(build);
+    return buildNote(e, relays, profiles.get(e.pubkey) ?? null, quoted, replies);
+  }
+
+  return topLevelEvents.map(build);
+}
+
+/**
+ * Breadth-first reply discovery. Starting from the top-level note ids, batch
+ * one relay query per depth level: `{ kinds:[1], '#e': [...idsAtThisLevel] }`.
+ * Stops when no new ids are found, when MAX_THREAD_DEPTH is hit, or when a
+ * single root subtree exceeds MAX_REPLIES_PER_THREAD events.
+ *
+ * `seedReplies` are events that came in on the original tag-based query and
+ * are themselves replies; they're placed iteratively against known ancestors
+ * before BFS so we don't refetch them.
+ */
+async function fetchReplyTree(
+  pool: import('nostr-tools').SimplePool,
+  relays: string[],
+  rootIds: string[],
+  seedReplies: Event[],
+): Promise<Map<string, Event[]>> {
+  const childrenByParent = new Map<string, Event[]>();
+  const allEventsById = new Map<string, Event>();
+  const rootByEventId = new Map<string, string>();
+  const eventsPerRoot = new Map<string, number>();
+
+  for (const id of rootIds) rootByEventId.set(id, id);
+
+  function addReply(parentId: string, replyEvent: Event): boolean {
+    if (allEventsById.has(replyEvent.id)) return false;
+    const root = rootByEventId.get(parentId);
+    if (!root) return false; // orphan — parent unknown
+    if ((eventsPerRoot.get(root) ?? 0) >= MAX_REPLIES_PER_THREAD) return false;
+    allEventsById.set(replyEvent.id, replyEvent);
+    rootByEventId.set(replyEvent.id, root);
+    eventsPerRoot.set(root, (eventsPerRoot.get(root) ?? 0) + 1);
+    const arr = childrenByParent.get(parentId) ?? [];
+    arr.push(replyEvent);
+    childrenByParent.set(parentId, arr);
+    return true;
+  }
+
+  // Iteratively place seed replies whose ancestor chain is already known.
+  // Repeats until a pass makes no progress so depth-N seeds find their depth-(N-1)
+  // seed parents.
+  let progress = true;
+  while (progress) {
+    progress = false;
+    for (const e of seedReplies) {
+      if (allEventsById.has(e.id)) continue;
+      const parentId = getParentEventId(e);
+      if (!parentId) continue;
+      if (rootByEventId.has(parentId) && addReply(parentId, e)) progress = true;
+    }
+  }
+
+  // BFS down. Frontier on each round = ids whose direct replies we still need
+  // to fetch. Start from every event we currently know about.
+  let frontier = new Set<string>(rootByEventId.keys());
+  for (let depth = 0; depth < MAX_THREAD_DEPTH; depth++) {
+    if (frontier.size === 0) break;
+    let events: Event[] = [];
+    try {
+      events = await pool.querySync(relays, {
+        kinds: [1],
+        '#e': Array.from(frontier),
+        limit: REPLY_QUERY_LIMIT,
+      });
+    } catch {
+      break;
+    }
+    const nextFrontier = new Set<string>();
+    for (const e of events) {
+      const parentId = getParentEventId(e);
+      if (!parentId) continue;
+      if (addReply(parentId, e)) nextFrontier.add(e.id);
+    }
+    frontier = nextFrontier;
+  }
+
+  return childrenByParent;
 }
 
 // Batch-fetch every event quote-referenced by the given notes. Used to

--- a/lib/nostr/index.ts
+++ b/lib/nostr/index.ts
@@ -25,6 +25,8 @@ export {
 
 export { useNostrFeed } from './use-feed';
 
+export { fetchViewerReposts, useViewerReposts } from './viewer-state';
+
 export {
   publishBoostNote,
 } from './boost-notes';

--- a/lib/nostr/viewer-state.ts
+++ b/lib/nostr/viewer-state.ts
@@ -1,0 +1,94 @@
+'use client';
+import { useEffect, useState } from 'react';
+import type { Event } from 'nostr-tools';
+import type { NostrIdentity } from './auth';
+import type { DiscoveredNote } from './discover';
+import { withPool } from './pool';
+import { DEFAULT_RELAYS } from './relays';
+
+/**
+ * Query relays for the viewer's kind:6 reposts targeting any of `noteIds`.
+ * Returns the set of note ids the viewer has reposted. One batched query —
+ * does not scale with `noteIds.length`.
+ */
+export async function fetchViewerReposts(opts: {
+  noteIds: string[];
+  viewerPubkey: string;
+  relays?: string[];
+}): Promise<Set<string>> {
+  const out = new Set<string>();
+  const ids = Array.from(new Set(opts.noteIds.filter((id) => id && id.length === 64)));
+  if (ids.length === 0) return out;
+  const relays = opts.relays ?? DEFAULT_RELAYS;
+  return withPool(relays, async (pool) => {
+    let events: Event[] = [];
+    try {
+      events = await pool.querySync(relays, {
+        kinds: [6],
+        authors: [opts.viewerPubkey],
+        '#e': ids,
+      });
+    } catch {
+      return out;
+    }
+    const idSet = new Set(ids);
+    for (const e of events) {
+      for (const t of e.tags) {
+        if (t[0] === 'e' && typeof t[1] === 'string' && idSet.has(t[1])) {
+          out.add(t[1]);
+          break;
+        }
+      }
+    }
+    return out;
+  });
+}
+
+// Walk the reply tree and collect every visible note id so the repost query
+// also covers nested replies, not just the top-level cards.
+function flattenIds(notes: DiscoveredNote[]): string[] {
+  const out: string[] = [];
+  function walk(n: DiscoveredNote) {
+    out.push(n.id);
+    for (const r of n.replies) walk(r);
+  }
+  for (const n of notes) walk(n);
+  return out;
+}
+
+/**
+ * Returns the set of note ids the signed-in viewer has reposted (kind:6).
+ * Re-fetches when notes or identity change. Empty set when not signed in.
+ */
+export function useViewerReposts(
+  notes: DiscoveredNote[] | null,
+  identity: NostrIdentity | null,
+): Set<string> {
+  const [reposted, setReposted] = useState<Set<string>>(() => new Set());
+
+  const pubkey = identity?.pubkey ?? null;
+  const idsKey = notes ? flattenIds(notes).sort().join(',') : '';
+
+  useEffect(() => {
+    if (!pubkey || !notes || notes.length === 0) {
+      setReposted(new Set());
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const result = await fetchViewerReposts({
+        noteIds: flattenIds(notes),
+        viewerPubkey: pubkey,
+      });
+      if (!cancelled) setReposted(result);
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // idsKey makes the effect re-run when the visible note set changes; pubkey
+    // re-runs on login/logout/account-switch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pubkey, idsKey]);
+
+  return reposted;
+}


### PR DESCRIPTION
Boost notes now fetch their NIP-10 reply threads (full tree, capped at
depth 6 / 200 events per root) and render replies always-expanded under
each card. Replies authored from this app, which inherit the parent's
NIP-73 podcast tags, are pulled out of the top-level feed and re-nested.

The repost button now reflects "you reposted this" across reloads by
querying the viewer's prior kind:6 events targeting visible notes, and
turns magenta when in the reposted state instead of just dimming.

https://claude.ai/code/session_01HZR6KM1AaWEFuWsovAZH3f