### PR TITLE
Format episode duration and player time as h:mm:ss

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { PodcastResults, EpisodeList, FavoritesList } from '@/components/lists';
 import { Player } from '@/components/player';
 import { NostrAuth } from '@/components/nostr-auth';
 import { GlobalNostrFeed } from '@/components/global-nostr-feed';
+import { BoltIcon } from '@/components/icons';
 import { useApp } from '@/lib/store';
 
 import type { Podcast } from '@/lib/types';
@@ -43,7 +44,7 @@ export default function Home() {
             className="flex items-baseline gap-2 hover:opacity-80 transition"
             aria-label="Go to home"
           >
-            <span className="text-bolt text-2xl">⚡</span>
+            <BoltIcon className="w-6 h-6 text-bolt" />
             <span className="font-display text-2xl">Boost Me Bitch</span>
             <span className="text-[10px] text-muted uppercase tracking-widest hidden sm:inline">
               podcasting 2.0

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,16 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState('');
   const [favoritesCollapsed, setFavoritesCollapsed] = useState(false);
+  const [searchKey, setSearchKey] = useState(0);
+
+  function goHome() {
+    setFeeds([]);
+    setSelected(null);
+    setQuery('');
+    setLoading(false);
+    setSearchKey((n) => n + 1);
+    if (typeof window !== 'undefined') window.scrollTo({ top: 0 });
+  }
   const favorites = useApp((s) => s.favorites);
   const hasFavorites = Object.keys(favorites).length > 0;
 
@@ -27,13 +37,18 @@ export default function Home() {
       {/* Header */}
       <header className="border-b border-bone/15 sticky top-0 z-20 bg-ink/90 backdrop-blur">
         <div className="max-w-7xl mx-auto px-4 py-4 flex items-center gap-4">
-          <div className="flex items-baseline gap-2">
+          <button
+            type="button"
+            onClick={goHome}
+            className="flex items-baseline gap-2 hover:opacity-80 transition"
+            aria-label="Go to home"
+          >
             <span className="text-bolt text-2xl">⚡</span>
-            <h1 className="font-display text-2xl">Boost Me Bitch</h1>
+            <span className="font-display text-2xl">Boost Me Bitch</span>
             <span className="text-[10px] text-muted uppercase tracking-widest hidden sm:inline">
               podcasting 2.0
             </span>
-          </div>
+          </button>
           <div className="flex-1" />
           <NostrAuth />
         </div>
@@ -48,6 +63,7 @@ export default function Home() {
         </h2>
         <div className="mt-8 max-w-xl">
           <SearchBar
+            key={searchKey}
             onResults={(f, q) => { setFeeds(f); setQuery(q); if (!f.length) setSelected(null); }}
             onLoading={setLoading}
           />

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -7,6 +7,15 @@ import { BoostModal } from './boost-modal';
 import { BoltIcon } from './icons';
 import { PodcastNostrFeed } from './podcast-nostr-feed';
 
+function fmtDuration(t: number) {
+  if (!isFinite(t) || t <= 0) return '';
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  const s = Math.floor(t % 60).toString().padStart(2, '0');
+  if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${s}`;
+  return `${m}:${s}`;
+}
+
 function FavHeart({ podcast }: { podcast: Podcast }) {
   const guid = podcast.podcastGuid;
   const isFav = useApp((s) => s.isFavorite(guid));
@@ -309,7 +318,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                 <div className="text-sm font-display leading-tight truncate">{e.title}</div>
                 <div className="text-[11px] text-muted flex gap-2 mt-0.5">
                   {e.datePublished && <span>{new Date(e.datePublished * 1000).toLocaleDateString()}</span>}
-                  {e.duration && <span>· {Math.round(e.duration / 60)}m</span>}
+                  {e.duration && <span>· {fmtDuration(e.duration)}</span>}
                   {e.value && <span className="text-bolt">· ⚡ V4V</span>}
                 </div>
               </div>

--- a/components/player.tsx
+++ b/components/player.tsx
@@ -6,8 +6,10 @@ import { BoltIcon } from './icons';
 
 function fmt(t: number) {
   if (!isFinite(t)) return '0:00';
-  const m = Math.floor(t / 60);
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
   const s = Math.floor(t % 60).toString().padStart(2, '0');
+  if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${s}`;
   return `${m}:${s}`;
 }
 


### PR DESCRIPTION
The episode list rendered durations like "225m" and the player progress
showed "225:07" for long episodes. Switch both to h:mm:ss when over an
hour, keeping m:ss for shorter clips.

https://claude.ai/code/session_01WMjgGbSE6SKa1B6o2JTPAe