### PR TITLE
Link podcast names in note cards into the show detail view

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,11 +12,15 @@ import type { Podcast } from '@/lib/types';
 
 export default function Home() {
   const [feeds, setFeeds] = useState<Podcast[]>([]);
-  const [selected, setSelected] = useState<Podcast | null>(null);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState('');
   const [favoritesCollapsed, setFavoritesCollapsed] = useState(false);
   const [searchKey, setSearchKey] = useState(0);
+  // `selected` lives in the Zustand store so cross-component surfaces (e.g.
+  // the podcast-name link in a Nostr note card) can route into the detail
+  // view without prop-drilling through the feed components.
+  const selected = useApp((s) => s.selectedPodcast);
+  const setSelected = useApp((s) => s.selectPodcast);
 
   function goHome() {
     setFeeds([]);

--- a/components/nostr-note-card.tsx
+++ b/components/nostr-note-card.tsx
@@ -100,6 +100,7 @@ export function NoteCard({
   const identity = useApp((s) => s.identity);
   const mutedPubkeys = useApp((s) => s.mutedPubkeys);
   const mutePubkey = useApp((s) => s.mutePubkey);
+  const selectPodcast = useApp((s) => s.selectPodcast);
   const name =
     note.author?.display_name?.trim() ||
     note.author?.name?.trim() ||
@@ -245,7 +246,16 @@ export function NoteCard({
             ) : null}
             <span className="truncate">
               <span className="text-nostr">→</span>{' '}
-              <span className="text-bone">{podcast.title}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  selectPodcast(podcast);
+                  if (typeof window !== 'undefined') window.scrollTo({ top: 0 });
+                }}
+                className="text-bone hover:text-bolt hover:underline underline-offset-2"
+              >
+                {podcast.title}
+              </button>
               {podcast.author ? <span className="text-muted"> · {podcast.author}</span> : null}
             </span>
           </div>

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -19,6 +19,12 @@ interface AppState {
   setPlaying: (b: boolean) => void;
   setPosition: (s: number) => void;
 
+  // The podcast currently shown in the detail view. Lifted into the store so
+  // surfaces outside `app/page.tsx` (e.g. a podcast-name link in a Nostr note
+  // card) can navigate to a show without prop-drilling.
+  selectedPodcast: Podcast | null;
+  selectPodcast: (p: Podcast | null) => void;
+
   favorites: Record<string, FavoritePodcast>;
   isFavorite: (guid: string | undefined) => boolean;
   addFavorite: (p: FavoritePodcast) => void;
@@ -51,6 +57,9 @@ export const useApp = create<AppState>((set, get) => ({
   togglePlay: () => set((s) => ({ isPlaying: !s.isPlaying })),
   setPlaying: (b) => set({ isPlaying: b }),
   setPosition: (s) => set({ positionSec: s }),
+
+  selectedPodcast: null,
+  selectPodcast: (p) => set({ selectedPodcast: p }),
 
   // Hydrate from the guest cache on store creation; once a user signs in,
   // nostr-auth.tsx replaces this with the per-npub set.


### PR DESCRIPTION
The "→ podcast title" line under each Nostr note card's author header is
now a button that opens that show in the in-app detail view. Lifts the
home page's `selected` state into the Zustand store so the note card can
route into the detail view without prop-drilling through the feed
components.

https://claude.ai/code/session_01X3bg7TSAc4gWRnqRxszRNk