### PR TITLE
Add Amber signer support for Android

### DIFF
--- a/app/amber-callback/page.tsx
+++ b/app/amber-callback/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+// Amber returns to this page with the request id (we set it when opening the
+// nostrsigner: URL) plus the result as a query param. We post the result via
+// BroadcastChannel back to the original tab and close ourselves so the user
+// sees the app, not a blank tab.
+
+import { useEffect, useState } from 'react';
+import {
+  AMBER_BROADCAST_CHANNEL,
+  type AmberResultMessage,
+} from '@/lib/nostr/amber';
+
+// Some Amber versions append the result with an extra '?' instead of '&'
+// (e.g. `?id=abc?event=xyz`). URLSearchParams treats only the first '?' as a
+// delimiter, so the second pair is silently merged into the first value.
+// Normalize by replacing every '?' after the leading one with '&' before
+// parsing, so both shapes work.
+function parseFlexibleSearch(search: string): URLSearchParams {
+  if (!search) return new URLSearchParams();
+  const stripped = search.replace(/^\?/, '');
+  const fixed = stripped.replace(/\?/g, '&');
+  return new URLSearchParams(fixed);
+}
+
+export default function AmberCallback() {
+  const [status, setStatus] = useState<'pending' | 'ok' | 'noop'>('pending');
+
+  useEffect(() => {
+    const params = parseFlexibleSearch(window.location.search);
+    const id = params.get('id');
+    const error = params.get('error') ?? params.get('rejected');
+    // Amber's web flow may return the result under different keys depending
+    // on returnType / type — check all the conventional ones.
+    const result =
+      params.get('event') ??
+      params.get('signature') ??
+      params.get('result') ??
+      params.get('value') ??
+      undefined;
+
+    if (!id) {
+      setStatus('noop');
+      return;
+    }
+
+    try {
+      const channel = new BroadcastChannel(AMBER_BROADCAST_CHANNEL);
+      const message: AmberResultMessage = error
+        ? { id, error }
+        : { id, result };
+      channel.postMessage(message);
+      channel.close();
+      setStatus('ok');
+    } catch {
+      setStatus('noop');
+      return;
+    }
+
+    // Brief delay so the BroadcastChannel message has time to flush before
+    // the tab closes. window.close() may be ignored by the browser if this
+    // tab wasn't opened by script — that's fine, we leave a friendly message.
+    const t = setTimeout(() => {
+      try {
+        window.close();
+      } catch {
+        /* swallow */
+      }
+    }, 150);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <main className="min-h-screen flex items-center justify-center px-6 text-center">
+      <div className="card p-8 max-w-md">
+        <div className="text-nostr text-2xl mb-2">◆</div>
+        {status === 'pending' && (
+          <p className="text-sm text-bone/80">Returning from Amber…</p>
+        )}
+        {status === 'ok' && (
+          <>
+            <p className="text-sm text-bone/80">Done. You can close this tab.</p>
+            <p className="text-[11px] text-muted mt-2">
+              If your browser kept this tab open, return to the original tab.
+            </p>
+          </>
+        )}
+        {status === 'noop' && (
+          <p className="text-sm text-bone/80">
+            No pending Amber request found. You can close this tab.
+          </p>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/components/nostr-auth.tsx
+++ b/components/nostr-auth.tsx
@@ -3,6 +3,10 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { nip19 } from 'nostr-tools';
 import {
   loginWithExtension,
+  loginWithAmber,
+  restoreAmberSigner,
+  clearAmberSigner,
+  isLikelyAndroid,
   shortNpub,
   fetchProfile,
   fetchRelayList,
@@ -98,6 +102,11 @@ export function NostrAuth() {
       if (decoded.type !== 'npub') return;
       pubkey = decoded.data;
     } catch { return; }
+    // If the user signed in with Amber, reinstall the AmberSigner polyfill on
+    // window.nostr before any signing operation runs. Synchronous; no popup.
+    if (storage.signer.get() === 'amber') {
+      restoreAmberSigner(pubkey);
+    }
     const bare: NostrIdentity = { pubkey, npub: stored };
     const cachedProfile = storage.profile.get(pubkey);
     if (cachedProfile) bare.profile = cachedProfile;
@@ -124,9 +133,23 @@ export function NostrAuth() {
       const id = await loginWithExtension();
       setIdentity(id);
       storage.npub.set(id.npub);
+      storage.signer.clear();
       loadProfile(id);
     } catch (e) {
       setErr(getErrorMessage(e, 'sign-in failed'));
+    } finally { setBusy(false); }
+  }
+
+  async function signinWithAmber() {
+    setBusy(true); setErr(null);
+    try {
+      const id = await loginWithAmber();
+      setIdentity(id);
+      storage.npub.set(id.npub);
+      storage.signer.set('amber');
+      loadProfile(id);
+    } catch (e) {
+      setErr(getErrorMessage(e, 'Amber sign-in failed'));
     } finally { setBusy(false); }
   }
 
@@ -135,18 +158,43 @@ export function NostrAuth() {
     setFavorites({});
     setMutedPubkeys(new Set());
     storage.npub.clear();
+    storage.signer.clear();
+    clearAmberSigner();
   }
 
   if (identity) {
     return <AccountMenu identity={identity} onSignOut={signout} />;
   }
 
+  // On Android, surface the Amber button first since the NIP-07 path needs a
+  // browser extension that isn't widely available on mobile. Desktop / iOS
+  // see the extension button first; Amber stays available as a fallback for
+  // anyone with a custom setup (e.g. browser DevTools port-forwarding).
+  const androidFirst = isLikelyAndroid();
+
+  const extensionButton = (
+    <button onClick={signin} disabled={busy} className="btn-ghost">
+      <span className="text-nostr">◆</span>
+      {busy ? 'Connecting…' : 'Sign in with Nostr'}
+    </button>
+  );
+
+  const amberButton = (
+    <button
+      onClick={signinWithAmber}
+      disabled={busy}
+      className="btn-ghost"
+      title="Sign in with the Amber Android signer"
+    >
+      <span className="text-nostr">◆</span>
+      {busy ? 'Connecting…' : 'Sign in with Amber'}
+    </button>
+  );
+
   return (
     <div className="flex flex-col items-end gap-1">
-      <button onClick={signin} disabled={busy} className="btn-ghost">
-        <span className="text-nostr">◆</span>
-        {busy ? 'Connecting…' : 'Sign in with Nostr'}
-      </button>
+      {androidFirst ? amberButton : extensionButton}
+      {androidFirst ? extensionButton : amberButton}
       {err && <span className="text-[10px] text-nostr/80 max-w-[260px] text-right">{err}</span>}
     </div>
   );

--- a/lib/nostr/amber.ts
+++ b/lib/nostr/amber.ts
@@ -1,0 +1,204 @@
+'use client';
+
+// NIP-55 Amber signer (Android).
+//
+// Amber is an Android-only Nostr signer app. There's no persistent web
+// connection — every request opens a tab navigating to a `nostrsigner:` deep
+// link, which launches Amber. After the user approves, Amber redirects to a
+// callback URL on our origin (handled by app/amber-callback/page.tsx). The
+// callback page extracts the result and posts it back via a BroadcastChannel
+// keyed by a per-request id, the popup closes itself, and the awaiting promise
+// resolves in the original tab.
+//
+// Trade-off worth knowing: each signEvent / nip04.* / nip44.* call shows the
+// Amber prompt. Background-published events that the rest of the app debounces
+// (favorites, mutes) will visibly prompt the user. That's inherent to the
+// NIP-55 web flow — there's no way to pre-authorize like NWC does.
+
+import { nip19, type Event, type EventTemplate } from 'nostr-tools';
+
+export const AMBER_BROADCAST_CHANNEL = 'bmb:amber-result';
+export const AMBER_CALLBACK_PATH = '/amber-callback';
+
+// 2 minutes — enough time to read the Amber prompt and tap approve. Any
+// longer and a forgotten request keeps the listener pinned forever; any
+// shorter and slow phones / Always-Allow re-prompts time out.
+const AMBER_TIMEOUT_MS = 120_000;
+
+export type AmberRequestType =
+  | 'get_public_key'
+  | 'sign_event'
+  | 'nip04_encrypt'
+  | 'nip04_decrypt'
+  | 'nip44_encrypt'
+  | 'nip44_decrypt';
+
+export interface AmberResultMessage {
+  id: string;
+  /** Hex pubkey, signed-event JSON, ciphertext, or plaintext (depending on type). */
+  result?: string;
+  /** Bare signature when Amber returns returnType=signature for sign_event. */
+  signature?: string;
+  /** Human-readable error message when Amber rejects or the user cancels. */
+  error?: string;
+}
+
+interface InvokeOptions {
+  type: AmberRequestType;
+  /** event JSON, plaintext, or ciphertext — encoded after `nostrsigner:`. */
+  payload?: string;
+  /** Peer pubkey for nip04/nip44 operations. */
+  pubkey?: string;
+  /** Amber's returnType param. `event` returns the signed event JSON for
+   *  sign_event; `signature` returns just the bare signature. We always use
+   *  `event` for sign_event so the caller gets a complete `Event`. */
+  returnType?: 'signature' | 'event';
+}
+
+function randomId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function buildSignerUrl(opts: InvokeOptions, callbackUrl: string): string {
+  const params = new URLSearchParams();
+  params.set('type', opts.type);
+  params.set('compressionType', 'none');
+  params.set('returnType', opts.returnType ?? 'signature');
+  params.set('callbackUrl', callbackUrl);
+  if (opts.pubkey) params.set('pubkey', opts.pubkey);
+  // Payload (event JSON / plaintext / ciphertext) goes immediately after the
+  // scheme, URI-encoded. Empty payload for get_public_key.
+  return `nostrsigner:${encodeURIComponent(opts.payload ?? '')}?${params.toString()}`;
+}
+
+async function invokeAmber(opts: InvokeOptions): Promise<string> {
+  if (typeof window === 'undefined') {
+    throw new Error('Amber signer requires a browser environment');
+  }
+  if (typeof BroadcastChannel === 'undefined') {
+    throw new Error('Your browser does not support BroadcastChannel — required for Amber.');
+  }
+
+  const id = randomId();
+  const callbackUrl = new URL(AMBER_CALLBACK_PATH, window.location.origin);
+  callbackUrl.searchParams.set('id', id);
+
+  const signerUrl = buildSignerUrl(opts, callbackUrl.toString());
+
+  return new Promise<string>((resolve, reject) => {
+    const channel = new BroadcastChannel(AMBER_BROADCAST_CHANNEL);
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const cleanup = () => {
+      channel.close();
+      if (timer) clearTimeout(timer);
+    };
+
+    channel.onmessage = (e) => {
+      const msg = e.data as AmberResultMessage | undefined;
+      if (!msg || msg.id !== id) return;
+      cleanup();
+      if (msg.error) return reject(new Error(msg.error));
+      const value = msg.result ?? msg.signature;
+      if (!value) return reject(new Error('Amber returned no result'));
+      resolve(value);
+    };
+
+    timer = setTimeout(() => {
+      cleanup();
+      reject(
+        new Error(
+          'Amber did not respond. Make sure the Amber app is installed and try again.',
+        ),
+      );
+    }, AMBER_TIMEOUT_MS);
+
+    // window.open with target=_blank: Android Chrome resolves nostrsigner: via
+    // the OS intent picker → Amber. After signing, Amber returns to callbackUrl
+    // in the same popup tab, which then posts via BroadcastChannel and closes.
+    const popup = window.open(signerUrl, '_blank');
+    if (!popup) {
+      cleanup();
+      reject(new Error('Browser blocked the Amber popup. Allow popups for this site and retry.'));
+    }
+  });
+}
+
+export interface AmberSignerInterface {
+  getPublicKey(): Promise<string>;
+  signEvent(template: EventTemplate): Promise<Event>;
+  nip04: {
+    encrypt(peerPubkey: string, plaintext: string): Promise<string>;
+    decrypt(peerPubkey: string, ciphertext: string): Promise<string>;
+  };
+  nip44: {
+    encrypt(peerPubkey: string, plaintext: string): Promise<string>;
+    decrypt(peerPubkey: string, ciphertext: string): Promise<string>;
+  };
+}
+
+export class AmberSigner implements AmberSignerInterface {
+  private cachedPubkey: string | null;
+
+  constructor(savedPubkey?: string) {
+    this.cachedPubkey = savedPubkey ?? null;
+  }
+
+  async getPublicKey(): Promise<string> {
+    if (this.cachedPubkey) return this.cachedPubkey;
+    const raw = await invokeAmber({ type: 'get_public_key' });
+    // Older Amber versions return the npub bech32 string; newer versions
+    // return raw hex. Normalize to hex so the rest of the app sees the same
+    // shape as a NIP-07 extension.
+    if (/^[0-9a-f]{64}$/i.test(raw)) {
+      this.cachedPubkey = raw.toLowerCase();
+    } else if (raw.startsWith('npub1')) {
+      const decoded = nip19.decode(raw);
+      if (decoded.type !== 'npub') {
+        throw new Error(`Amber returned unexpected pubkey shape: ${raw.slice(0, 24)}…`);
+      }
+      this.cachedPubkey = decoded.data;
+    } else {
+      throw new Error(`Amber returned unexpected pubkey shape: ${raw.slice(0, 24)}…`);
+    }
+    return this.cachedPubkey;
+  }
+
+  async signEvent(template: EventTemplate): Promise<Event> {
+    const eventJson = JSON.stringify(template);
+    const signed = await invokeAmber({
+      type: 'sign_event',
+      payload: eventJson,
+      returnType: 'event',
+    });
+    try {
+      return JSON.parse(signed) as Event;
+    } catch {
+      throw new Error('Amber returned a malformed signed event');
+    }
+  }
+
+  nip04 = {
+    encrypt: (peerPubkey: string, plaintext: string) =>
+      invokeAmber({ type: 'nip04_encrypt', payload: plaintext, pubkey: peerPubkey }),
+    decrypt: (peerPubkey: string, ciphertext: string) =>
+      invokeAmber({ type: 'nip04_decrypt', payload: ciphertext, pubkey: peerPubkey }),
+  };
+
+  nip44 = {
+    encrypt: (peerPubkey: string, plaintext: string) =>
+      invokeAmber({ type: 'nip44_encrypt', payload: plaintext, pubkey: peerPubkey }),
+    decrypt: (peerPubkey: string, ciphertext: string) =>
+      invokeAmber({ type: 'nip44_decrypt', payload: ciphertext, pubkey: peerPubkey }),
+  };
+}
+
+/** Loose Android UA sniff. False negatives are fine — the Amber button is
+ *  shown anyway when no NIP-07 extension is detected, so iOS / desktop users
+ *  see it as a fallback option. */
+export function isLikelyAndroid(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /android/i.test(navigator.userAgent);
+}

--- a/lib/nostr/auth.ts
+++ b/lib/nostr/auth.ts
@@ -1,8 +1,13 @@
 // NIP-07 sign-in. The window globals declared here cover both the Nostr
 // signer and the WebLN provider (Lightning lib in @/lib/v4v/webln also uses
 // it via this same module-level declaration).
+//
+// Amber (NIP-55, Android) is supported by polyfilling window.nostr with an
+// AmberSigner instance — see lib/nostr/signer.ts and lib/nostr/amber.ts. The
+// rest of the app reads window.nostr without caring which backend it is.
 
 import { nip19, type Event, type EventTemplate } from 'nostr-tools';
+import { activateAmberSigner, deactivateAmberSigner } from './signer';
 
 declare global {
   interface Window {
@@ -58,6 +63,44 @@ export async function loginWithExtension(): Promise<NostrIdentity> {
   }
   const pubkey = await window.nostr.getPublicKey();
   return { pubkey, npub: nip19.npubEncode(pubkey) };
+}
+
+/**
+ * Sign in via the Amber Android signer (NIP-55). Installs an AmberSigner as
+ * window.nostr so subsequent signEvent / nip04 / nip44 calls route through
+ * the same `nostrsigner:` deep-link flow; the original window.nostr (a
+ * NIP-07 extension, if any) is restored on sign-out.
+ *
+ * The first call opens an Amber popup tab to fetch the pubkey. Subsequent
+ * page loads can call `restoreAmberSigner` instead — synchronous, no popup.
+ */
+export async function loginWithAmber(): Promise<NostrIdentity> {
+  const signer = activateAmberSigner();
+  try {
+    const pubkey = await signer.getPublicKey();
+    return { pubkey, npub: nip19.npubEncode(pubkey) };
+  } catch (e) {
+    // Roll back the polyfill if Amber rejected/timed out — otherwise we'd
+    // leave window.nostr pointing at an Amber instance the user never agreed
+    // to, and the next signEvent would silently re-prompt them through Amber.
+    deactivateAmberSigner();
+    throw e;
+  }
+}
+
+/**
+ * Reinstall the AmberSigner polyfill on page load when the user previously
+ * signed in with Amber. Synchronous — does NOT call Amber. The cached pubkey
+ * lets the signer answer getPublicKey() without a popup, mirroring how
+ * NIP-07 extensions hold the pubkey in memory.
+ */
+export function restoreAmberSigner(pubkey: string) {
+  activateAmberSigner(pubkey);
+}
+
+/** Drop the Amber polyfill, restoring the underlying window.nostr (if any). */
+export function clearAmberSigner() {
+  deactivateAmberSigner();
 }
 
 export function shortNpub(npub: string, len = 8) {

--- a/lib/nostr/index.ts
+++ b/lib/nostr/index.ts
@@ -4,10 +4,16 @@
 
 export {
   loginWithExtension,
+  loginWithAmber,
+  restoreAmberSigner,
+  clearAmberSigner,
   shortNpub,
   type NostrIdentity,
   type ProfileMetadata,
 } from './auth';
+
+export { isAmberActive } from './signer';
+export { isLikelyAndroid } from './amber';
 
 export { fetchProfile } from './profile';
 

--- a/lib/nostr/signer.ts
+++ b/lib/nostr/signer.ts
@@ -1,0 +1,52 @@
+'use client';
+
+// Centralized control over which signer the rest of the app sees.
+//
+// The whole codebase (publish.ts, mutes.ts, wallet-backup.ts, zap.ts, auth.ts)
+// reads from `window.nostr`. To avoid touching every call site we polyfill
+// `window.nostr` with the AmberSigner when the user has chosen Amber, and
+// restore the original (a NIP-07 extension, if any) on sign-out.
+//
+// This module owns the swap. Callers should use:
+//   activateAmberSigner(pubkey?)  — install AmberSigner as window.nostr
+//   deactivateAmberSigner()       — restore the original window.nostr
+//   isAmberActive()               — true while AmberSigner is the active signer
+
+import { AmberSigner } from './amber';
+
+let amberInstance: AmberSigner | null = null;
+// Captured once on first activation per page. We don't recapture on
+// re-activation because window.nostr would already be our AmberSigner — the
+// "original" we want to restore is the underlying extension, not ourselves.
+let originalWindowNostr: Window['nostr'] | undefined;
+let originalCaptured = false;
+
+export function activateAmberSigner(pubkey?: string): AmberSigner {
+  if (typeof window === 'undefined') {
+    throw new Error('Amber signer requires a browser environment');
+  }
+  if (!originalCaptured) {
+    originalWindowNostr = window.nostr;
+    originalCaptured = true;
+  }
+  amberInstance = new AmberSigner(pubkey);
+  // Cast: AmberSigner satisfies the structural shape declared in auth.ts.
+  window.nostr = amberInstance as unknown as Window['nostr'];
+  return amberInstance;
+}
+
+export function deactivateAmberSigner() {
+  if (typeof window === 'undefined') return;
+  amberInstance = null;
+  if (originalCaptured) {
+    window.nostr = originalWindowNostr;
+  }
+}
+
+export function isAmberActive(): boolean {
+  return amberInstance !== null;
+}
+
+export function getActiveAmber(): AmberSigner | null {
+  return amberInstance;
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -10,6 +10,7 @@ import type { DiscoveredNote, ProfileMetadata } from './nostr';
 
 const KEYS = {
   npub: 'bmb:npub',
+  signer: 'bmb:signer',               // 'amber' when Amber is the active signer; absent = NIP-07 extension or none
   nwcUri: 'bmb:nwc_uri',
   relays: 'bmb:relays',
   senderName: 'bmb:sender_name',
@@ -21,6 +22,8 @@ const KEYS = {
   profilePrefix: 'bmb:profile3',      // kind:0 metadata, keyed by pubkey (hex). Bumped on each PROFILE_RELAYS expansion so stale negative-cache entries don't pin missing profiles for the 1-hour miss TTL.
   mutedPrefix: 'bmb:muted',           // NIP-51 kind:10000 mute list cache, keyed by npub or 'guest'
 } as const;
+
+export type SignerKind = 'amber';
 
 const BOOSTS_CAP = 200;
 
@@ -82,6 +85,18 @@ export const storage = {
     get: () => safeGet(KEYS.npub),
     set: (v: string) => safeSet(KEYS.npub, v),
     clear: () => safeRemove(KEYS.npub),
+  },
+
+  /** Which signer the user picked. Absent = NIP-07 extension or signed out;
+   *  'amber' = use the Android Amber app via NIP-55 deep links. Read on page
+   *  load to decide whether to install the Amber polyfill onto window.nostr. */
+  signer: {
+    get: (): SignerKind | null => {
+      const v = safeGet(KEYS.signer);
+      return v === 'amber' ? 'amber' : null;
+    },
+    set: (v: SignerKind) => safeSet(KEYS.signer, v),
+    clear: () => safeRemove(KEYS.signer),
   },
 
   nwcUri: {


### PR DESCRIPTION
Amber (NIP-55) is the de facto Android Nostr signer. The web flow uses
nostrsigner: deep links: each request opens a popup tab, Amber takes
over via the OS, and redirects back to /amber-callback which posts the
result via BroadcastChannel and closes itself.

AmberSigner is installed as window.nostr while active, so the existing
publish / mutes / wallet-backup / zap call sites work unchanged. The
original window.nostr (a NIP-07 extension, if any) is restored on
sign-out. bmb:signer persists the choice across reloads so we can
reinstall the polyfill without re-prompting Amber.

The button order follows platform: Android sees Amber first, everyone
else sees the extension button first with Amber as a fallback.