### PR TITLE
Consolidate Lightning wallet into a single modal in the account menu

### DIFF
--- a/components/nostr-auth.tsx
+++ b/components/nostr-auth.tsx
@@ -25,15 +25,13 @@ import {
   type ProfileMetadata,
 } from '@/lib/nostr';
 import { getLatestPendingAmber, submitManualAmberResult, subscribeAmberStage } from '@/lib/nostr/amber';
-import { hasSpark, sparkInitFromMnemonic } from '@/lib/v4v/spark';
-import { hasWebln } from '@/lib/v4v/webln';
+import { hasSpark, sparkInitFromMnemonic, subscribeSpark } from '@/lib/v4v/spark';
+import { hasNwc, subscribeNwc } from '@/lib/v4v/nwc';
 import { useApp } from '@/lib/store';
 import { storage } from '@/lib/storage';
 import { getErrorMessage } from '@/lib/util';
 import { Avatar } from './avatar';
-import { SparkWallet } from './spark-wallet';
-import { NwcWallet } from './nwc-wallet';
-import { WeblnWallet } from './webln-wallet';
+import { WalletModal } from './wallet-modal';
 
 // Module-level promise cache keyed by pubkey, so the same loadProfile call
 // isn't fired twice when React remounts the component (StrictMode in dev,
@@ -788,6 +786,7 @@ function AccountMenu({
   onSignOut: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [walletOpen, setWalletOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
 
   // Dismiss on click-outside / Escape so the menu doesn't trap focus.
@@ -851,30 +850,7 @@ function AccountMenu({
 
           <BunkerHealthBanner />
 
-          <div className="text-[11px] uppercase tracking-widest text-muted">
-            Connect wallet
-          </div>
-
-          <div className="mt-2 text-[11px] uppercase tracking-widest text-bone/60">NWC</div>
-          <NwcWallet />
-
-          <div className="mt-4 text-[11px] uppercase tracking-widest text-bone/60">Spark</div>
-          <SparkWallet />
-
-          {/* WebLN is browser-extension only (Alby on desktop, Mutiny's
-              in-app browser, Kiwi on Android). Hide the whole sub-card
-              on platforms where window.webln isn't injected — most
-              users on iOS / Android / vanilla desktop without Alby
-              will never see it light up, so the empty "Not detected"
-              hint was just clutter. Re-check on every menu open so an
-              extension install in the same session shows up next time
-              the avatar is clicked. */}
-          {hasWebln() && (
-            <>
-              <div className="mt-4 text-[11px] uppercase tracking-widest text-bone/60">WebLN</div>
-              <WeblnWallet />
-            </>
-          )}
+          <WalletButton onClick={() => setWalletOpen(true)} />
 
           <MutedAccountsSection />
 
@@ -888,7 +864,51 @@ function AccountMenu({
           </div>
         </div>
       )}
+      {walletOpen && <WalletModal onClose={() => setWalletOpen(false)} />}
     </div>
+  );
+}
+
+// Single-row summary that replaces the inline NWC / Spark / WebLN cards in
+// the account menu. Reads each rail's connect state on every render and
+// re-renders on rail-state changes so disconnecting from inside the modal
+// flips the summary back to "Not connected" without remounting the menu.
+function WalletButton({ onClick }: { onClick: () => void }) {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const bump = () => setTick((t) => t + 1);
+    const unsubSpark = subscribeSpark(bump);
+    const unsubNwc = subscribeNwc(bump);
+    return () => { unsubSpark(); unsubNwc(); };
+  }, []);
+
+  const sparkReady = hasSpark();
+  const nwcReady = hasNwc();
+  // Spark is preferred in the summary because it's the richer surface
+  // (balance + receive). NWC takes priority over Spark in pickRail() for
+  // sending, but here we're describing the user's setup, not routing.
+  const summary = sparkReady
+    ? 'Spark wallet'
+    : nwcReady
+      ? 'NWC connected'
+      : 'Not connected';
+  const connected = sparkReady || nwcReady;
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="card mt-2 mb-1 p-3 w-full flex items-center justify-between hover:border-bolt/40 transition text-left"
+    >
+      <span className="flex items-center gap-2">
+        <span className={connected ? 'text-bolt text-base' : 'text-muted text-base'}>⚡</span>
+        <span className="flex flex-col">
+          <span className="text-[11px] uppercase tracking-widest text-muted">Lightning wallet</span>
+          <span className="text-sm">{summary}</span>
+        </span>
+      </span>
+      <span className="text-[11px] text-muted">{connected ? 'Manage' : 'Connect'} →</span>
+    </button>
   );
 }
 

--- a/components/wallet-modal.tsx
+++ b/components/wallet-modal.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+// Lightning wallet modal — a single overlay that consolidates the three
+// wallet rails (NWC / Spark / WebLN) so the account menu doesn't have to
+// stack three sub-cards. Triggered by the WalletButton in AccountMenu.
+//
+// Display rule: when ANY rail is connected (NWC URI saved or Spark SDK
+// initialized), only the connected rail(s) are shown. The unconnected
+// connect forms only appear when nothing is connected — keeping the
+// account menu uncluttered after the user picks their wallet. WebLN is
+// tracked as "available" rather than "connected" (the extension is either
+// injected or it isn't) so it surfaces alongside the connect options.
+
+import { useEffect, useState } from 'react';
+import { hasNwc, subscribeNwc } from '@/lib/v4v/nwc';
+import { hasSpark, subscribeSpark } from '@/lib/v4v/spark';
+import { hasWebln } from '@/lib/v4v/webln';
+import { NwcWallet } from './nwc-wallet';
+import { SparkWallet } from './spark-wallet';
+import { WeblnWallet } from './webln-wallet';
+
+interface Props {
+  onClose: () => void;
+}
+
+export function WalletModal({ onClose }: Props) {
+  // Bump on either rail's state change so the modal flips between
+  // "connected wallets only" and "all options" without remounting.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const bump = () => setTick((t) => t + 1);
+    const unsubSpark = subscribeSpark(bump);
+    const unsubNwc = subscribeNwc(bump);
+    return () => { unsubSpark(); unsubNwc(); };
+  }, []);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  const nwcReady = hasNwc();
+  const sparkReady = hasSpark();
+  const weblnAvailable = hasWebln();
+  const anyConnected = nwcReady || sparkReady;
+
+  return (
+    <div className="fixed inset-0 z-40 bg-ink/85 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="card w-full max-w-md bg-ink relative max-h-[92vh] overflow-y-auto">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-3 text-muted hover:text-bone text-lg z-10"
+          aria-label="Close"
+        >
+          ×
+        </button>
+
+        <div className="p-5 border-b border-bone/15">
+          <div className="stamp text-bolt border-bolt/60 mb-2">⚡ LIGHTNING WALLET</div>
+          <h3 className="font-display text-2xl leading-tight">
+            {anyConnected ? 'Connected' : 'Connect a wallet'}
+          </h3>
+          <p className="text-xs text-muted mt-1">
+            {anyConnected
+              ? 'Disconnect below to switch to a different wallet.'
+              : 'Pick one option to send Lightning payments.'}
+          </p>
+        </div>
+
+        <div className="p-5 space-y-5">
+          {nwcReady && (
+            <section>
+              <div className="text-[11px] uppercase tracking-widest text-bone/60">NWC</div>
+              <NwcWallet />
+            </section>
+          )}
+
+          {sparkReady && (
+            <section>
+              <div className="text-[11px] uppercase tracking-widest text-bone/60">Spark</div>
+              <SparkWallet />
+            </section>
+          )}
+
+          {!anyConnected && (
+            <>
+              <section>
+                <div className="text-[11px] uppercase tracking-widest text-bone/60">NWC</div>
+                <NwcWallet />
+              </section>
+              <section>
+                <div className="text-[11px] uppercase tracking-widest text-bone/60">Spark</div>
+                <SparkWallet />
+              </section>
+              {weblnAvailable && (
+                <section>
+                  <div className="text-[11px] uppercase tracking-widest text-bone/60">WebLN</div>
+                  <WeblnWallet />
+                </section>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/v4v/nwc.ts
+++ b/lib/v4v/nwc.ts
@@ -4,10 +4,25 @@
 import { nwc } from '@getalby/sdk';
 import { storage } from '../storage';
 
+// Components reading hasNwc() during render need to refresh when an outside
+// actor flips the connect state — most commonly the wallet modal showing the
+// connect form alongside another component reading the same flag. The Spark
+// rail uses the same pattern (lib/v4v/spark.ts:subscribeSpark).
+const listeners = new Set<() => void>();
+
+function notify() {
+  listeners.forEach((fn) => { try { fn(); } catch { /* ignore */ } });
+}
+
+export function subscribeNwc(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}
+
 // Re-export the URI accessors so existing call sites keep their imports.
-export const saveNwcUri = (uri: string) => storage.nwcUri.set(uri);
+export const saveNwcUri = (uri: string) => { storage.nwcUri.set(uri); notify(); };
 export const loadNwcUri = () => storage.nwcUri.get();
-export const clearNwcUri = () => storage.nwcUri.clear();
+export const clearNwcUri = () => { storage.nwcUri.clear(); notify(); };
 export const hasNwc = () => storage.nwcUri.has();
 
 function client() {


### PR DESCRIPTION
The account menu used to stack three sub-cards (NWC, Spark, WebLN) inline.
Replace that with one summary button ("⚡ Lightning wallet — Spark wallet
/ NWC connected / Not connected — Manage / Connect") that opens a
dedicated WalletModal. Inside the modal, only the connected rail(s) show
once anything is connected; the unconnected connect forms only appear
when nothing is set up. WebLN is treated as an optional alongside the
connect options (the extension is either injected or it isn't).

Adds subscribeNwc to lib/v4v/nwc.ts mirroring the Spark listener pattern,
so WalletButton + WalletModal flip between "connected only" and "all
options" without remounting when the user connects/disconnects from
inside the modal.

https://claude.ai/code/session_01VtivrDEj7HVVuqoAoEuZAk