### PR TITLE
Sanitize kind:0 profile JSON + add a route-level error boundary

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+// Route-segment error boundary. Next.js mounts this when any client component
+// inside `app/page.tsx` throws during render, instead of replacing the entire
+// document with the default "Application error" message. The user keeps the
+// header / hero and can `Try again` to remount, or `← back to home` to clear
+// whatever state (selected podcast, stale cache hit) tripped the throw.
+
+import { useEffect } from 'react';
+import { useApp } from '@/lib/store';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const setSelected = useApp((s) => s.selectPodcast);
+
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error('[boostmebitch] route error:', error);
+  }, [error]);
+
+  return (
+    <main className="min-h-screen pb-32 px-4 pt-[env(safe-area-inset-top)]">
+      <div className="max-w-xl mx-auto pt-20">
+        <div className="card p-5">
+          <h2 className="font-display text-2xl">Something broke on this page</h2>
+          <p className="text-sm text-muted mt-2">
+            One of the components on this view threw while rendering. The rest
+            of the app is fine — try the buttons below.
+          </p>
+          {error?.message && (
+            <pre className="text-[11px] text-muted/80 font-mono mt-3 whitespace-pre-wrap break-words border border-bone/10 p-2">
+              {error.message}
+            </pre>
+          )}
+          <div className="flex flex-wrap gap-2 mt-4">
+            <button onClick={reset} className="btn">Try again</button>
+            <button
+              onClick={() => { setSelected(null); reset(); }}
+              className="btn-ghost"
+            >
+              ← back to home
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -288,7 +288,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
               aria-expanded={valueOpen}
               title={valueOpen ? 'Hide split details' : 'Show split details'}
             >
-              ⚡ {data.podcast.value.recipients.length} recipients · {data.podcast.value.method}
+              ⚡ {data.podcast.value.recipients?.length ?? 0} recipients · {data.podcast.value.method}
               <span className="ml-1">{valueOpen ? '▾' : '▸'}</span>
             </button>
           )}

--- a/lib/nostr/auth.ts
+++ b/lib/nostr/auth.ts
@@ -197,3 +197,38 @@ export function shortNpub(npub: string, len = 8) {
   if (npub.length <= len * 2 + 1) return npub;
   return `${npub.slice(0, len)}…${npub.slice(-len)}`;
 }
+
+// Drop fields that aren't strings (some kind:0 events in the wild ship `name`
+// as a number, `picture` as null, etc., and the `as ProfileMetadata` cast at
+// JSON.parse-time hides that — until a `.trim()` or `.toLowerCase()` blows up
+// during render and takes the whole feed surface down with it).
+const PROFILE_STRING_FIELDS = [
+  'name',
+  'display_name',
+  'picture',
+  'nip05',
+  'about',
+  'lud16',
+  'lud06',
+] as const;
+
+export function coerceProfileMetadata(value: unknown): ProfileMetadata | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  const out: ProfileMetadata = {};
+  for (const key of PROFILE_STRING_FIELDS) {
+    const raw = v[key];
+    if (typeof raw === 'string') out[key] = raw;
+  }
+  return out;
+}
+
+/** Parse a kind:0 event's `content` and return a sanitized ProfileMetadata.
+ *  Returns null if the content isn't valid JSON or isn't an object. */
+export function parseProfileContent(content: string): ProfileMetadata | null {
+  try {
+    return coerceProfileMetadata(JSON.parse(content));
+  } catch {
+    return null;
+  }
+}

--- a/lib/nostr/discover.ts
+++ b/lib/nostr/discover.ts
@@ -2,7 +2,7 @@ import { nip19, type Event } from 'nostr-tools';
 import { withPool, withExtraRelays, FEED_QUERY_MAX_WAIT_MS } from './pool';
 import { DEFAULT_RELAYS, PROFILE_RELAYS } from './relays';
 import { storage } from '../storage';
-import type { ProfileMetadata } from './auth';
+import { parseProfileContent, type ProfileMetadata } from './auth';
 
 export interface DiscoveredNote {
   id: string;
@@ -449,11 +449,8 @@ function newestProfilesByAuthor(
   }
   const out = new Map<string, ProfileMetadata>();
   for (const [pubkey, e] of newest) {
-    try {
-      out.set(pubkey, JSON.parse(e.content) as ProfileMetadata);
-    } catch {
-      // ignore unparseable content
-    }
+    const profile = parseProfileContent(e.content);
+    if (profile) out.set(pubkey, profile);
   }
   return out;
 }

--- a/lib/nostr/profile.ts
+++ b/lib/nostr/profile.ts
@@ -1,7 +1,7 @@
 import { withPool, QUERY_MAX_WAIT_MS } from './pool';
 import { DEFAULT_RELAYS, PROFILE_RELAYS } from './relays';
 import { storage } from '../storage';
-import type { ProfileMetadata } from './auth';
+import { parseProfileContent, type ProfileMetadata } from './auth';
 
 // Fetch the user's kind:0 metadata event from the given relays (defaults to
 // our standard set unioned with the profile-outbox relays). Returns null if
@@ -26,7 +26,11 @@ export async function fetchProfile(
         return null;
       }
       const newest = events.sort((a, b) => b.created_at - a.created_at)[0];
-      const profile = JSON.parse(newest.content) as ProfileMetadata;
+      const profile = parseProfileContent(newest.content);
+      if (!profile) {
+        storage.profile.setMiss(pubkey);
+        return null;
+      }
       storage.profile.set(pubkey, profile);
       return profile;
     } catch {

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -7,6 +7,7 @@
 
 import type { FavoritePodcast, Podcast, StoredBoost } from './types';
 import type { DiscoveredNote, MuteListState, ProfileMetadata } from './nostr';
+import { coerceProfileMetadata } from './nostr/auth';
 
 const KEYS = {
   npub: 'bmb:npub',
@@ -362,7 +363,11 @@ export const storage = {
         if (!cell || typeof cell.t !== 'number') return undefined;
         const ttl = cell.v === null ? PROFILE_MISS_TTL_MS : PROFILE_TTL_MS;
         if (Date.now() - cell.t > ttl) return undefined;
-        return cell.v;
+        // Re-coerce on read so caches written by older versions of the app
+        // (which trusted the kind:0 JSON shape) can't ship a non-string
+        // `name` / `display_name` to the UI and crash a `.trim()` call.
+        if (cell.v === null) return null;
+        return coerceProfileMetadata(cell.v);
       } catch {
         return undefined;
       }


### PR DESCRIPTION
Some kind:0 events in the wild ship `name`/`display_name`/`picture` as
non-strings (numbers, null, objects). The `as ProfileMetadata` cast at
JSON.parse-time hides that — until a `.trim()` call in a NoteCard or
account menu blows up while rendering the per-podcast Nostr feed and
takes the whole page down with the default "Application error" overlay.
That's the symptom users hit when they navigate to a podcast whose
boost authors have a malformed kind:0 (Local Bitcoiners is one such).

`coerceProfileMetadata` filters every ProfileMetadata field down to
genuine strings, dropping anything else. Wired in at:

- lib/nostr/profile.ts  — fetchProfile parse site
- lib/nostr/discover.ts — newestProfilesByAuthor parse site
- lib/storage.ts        — re-coerce on cache read so caches written by
                          older versions of the app don't keep crashing
                          for the next 7 days until their TTL expires

Also adds app/error.tsx as a last-resort route-segment boundary: if any
component below `app/page.tsx` still throws, the user sees a contained
"Something broke" card with retry / back-to-home buttons instead of
losing the entire document. The header / hero stay rendered.

https://claude.ai/code/session_013nrFdMM5kw7NiTJgGJyPQe