### PR TITLE
Tolerate cached notes that predate the replies field

### DIFF
--- a/components/nostr-note-card.tsx
+++ b/components/nostr-note-card.tsx
@@ -105,7 +105,7 @@ export function NoteCard({
     note.author?.display_name?.trim() ||
     note.author?.name?.trim() ||
     shortNpub(note.npub);
-  const visibleReplies = note.replies.filter((r) => !mutedPubkeys.has(r.pubkey));
+  const visibleReplies = (note.replies ?? []).filter((r) => !mutedPubkeys.has(r.pubkey));
   const sats =
     note.amountMsat && note.amountMsat > 0
       ? Math.round(note.amountMsat / 1000)

--- a/lib/nostr/viewer-state.ts
+++ b/lib/nostr/viewer-state.ts
@@ -50,7 +50,7 @@ function flattenIds(notes: DiscoveredNote[]): string[] {
   const out: string[] = [];
   function walk(n: DiscoveredNote) {
     out.push(n.id);
-    for (const r of n.replies) walk(r);
+    for (const r of n.replies ?? []) walk(r);
   }
   for (const n of notes) walk(n);
   return out;

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -295,9 +295,19 @@ export const storage = {
       if (!raw) return null;
       try {
         const parsed = JSON.parse(raw);
-        if (Array.isArray(parsed)) return parsed as DiscoveredNote[];
-        if (parsed && Array.isArray(parsed.v)) return parsed.v as DiscoveredNote[];
-        return null;
+        const arr: unknown = Array.isArray(parsed)
+          ? parsed
+          : parsed && Array.isArray(parsed.v)
+            ? parsed.v
+            : null;
+        if (!arr) return null;
+        // Notes cached before `replies` was added on the type would crash any
+        // consumer that iterates `note.replies`. Normalize recursively here.
+        const normalize = (n: DiscoveredNote): DiscoveredNote => ({
+          ...n,
+          replies: Array.isArray(n.replies) ? n.replies.map(normalize) : [],
+        });
+        return (arr as DiscoveredNote[]).map(normalize);
       } catch {
         return null;
       }


### PR DESCRIPTION
Older bmb:feed:* entries were serialized before DiscoveredNote.replies
existed; reading them back gave undefined, and the kind:6 repost walk
in viewer-state.ts crashed the route ("undefined is not an object
(evaluating 'n.replies')"). Try-Again rehydrated the same cache and
looped. Normalize replies to [] at the cache boundary, and defend the
two iteration sites.