### PR TITLE
Time-bound bunker connect + better Primal iOS auth-URL surface

### DIFF
--- a/components/nostr-auth.tsx
+++ b/components/nostr-auth.tsx
@@ -586,6 +586,11 @@ function OtherSignIn({
 
       {tab === 'have' && (
         <>
+          <span className="text-[10px] text-muted self-stretch text-right">
+            Primal: Settings → Keys → Remote Signer → copy the connection
+            string. Keep Primal in the foreground (or with audio playing on
+            iOS) so it can answer signing requests.
+          </span>
           <textarea
             value={pasteValue}
             onChange={(e) => setPasteValue(e.target.value)}
@@ -603,14 +608,24 @@ function OtherSignIn({
             </button>
           </div>
           {pasteAuthUrl && (
-            <a
-              href={pasteAuthUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[11px] text-nostr underline break-all self-stretch text-right"
-            >
-              ◆ Open auth URL to approve
-            </a>
+            <div className="self-stretch flex flex-col items-end gap-1 mt-1 border border-nostr/40 bg-nostr/10 p-2">
+              <span className="text-[10px] text-bone text-right">
+                Your signer wants you to approve this connection.
+              </span>
+              <a
+                href={pasteAuthUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-bolt text-[11px] py-1 px-3 no-underline"
+              >
+                ◆ Approve in signer
+              </a>
+              <span className="text-[10px] text-muted text-right">
+                Approve in your signer (Primal, Clave, …) then come back here.
+                Keep this tab open while you approve — closing it cancels the
+                connection.
+              </span>
+            </div>
           )}
           {pasteErr && (
             <span className="text-[10px] text-nostr/80 text-right">{pasteErr}</span>
@@ -663,14 +678,22 @@ function OtherSignIn({
             </>
           )}
           {genAuthUrl && (
-            <a
-              href={genAuthUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-[11px] text-nostr underline break-all self-stretch text-right"
-            >
-              ◆ Open auth URL to approve
-            </a>
+            <div className="self-stretch flex flex-col items-end gap-1 mt-1 border border-nostr/40 bg-nostr/10 p-2">
+              <span className="text-[10px] text-bone text-right">
+                Your signer wants you to approve this connection.
+              </span>
+              <a
+                href={genAuthUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="btn-bolt text-[11px] py-1 px-3 no-underline"
+              >
+                ◆ Approve in signer
+              </a>
+              <span className="text-[10px] text-muted text-right">
+                Keep this tab open while you approve.
+              </span>
+            </div>
           )}
           {genErr && (
             <span className="text-[10px] text-nostr/80 text-right">{genErr}</span>

--- a/components/nostr-auth.tsx
+++ b/components/nostr-auth.tsx
@@ -11,6 +11,7 @@ import {
   restoreBunkerSigner,
   clearAmberSigner,
   clearBunkerSigner,
+  clearPendingBunkerAttempts,
   isLikelyAndroid,
   isLikelyIOS,
   subscribeBunkerHealth,
@@ -576,7 +577,13 @@ function OtherSignIn({
         <span className="flex-1" />
         <button
           type="button"
-          onClick={() => setOpen(false)}
+          onClick={() => {
+            // Drop any half-finished paste attempt so a future session
+            // starts clean — the memo is keyed on URI but the user may
+            // change which signer they're pairing with next time.
+            clearPendingBunkerAttempts();
+            setOpen(false);
+          }}
           className="text-muted hover:text-bone text-base leading-none"
           aria-label="Close"
         >
@@ -588,8 +595,10 @@ function OtherSignIn({
         <>
           <span className="text-[10px] text-muted self-stretch text-right">
             Primal: Settings → Keys → Remote Signer → copy the connection
-            string. Keep Primal in the foreground (or with audio playing on
-            iOS) so it can answer signing requests.
+            string. On iOS, enable background audio in Primal first so it
+            stays alive for signing requests. After approving in Primal,
+            return here and tap <span className="text-bone">Connect</span>{' '}
+            again if it didn&apos;t finish — your approval is remembered.
           </span>
           <textarea
             value={pasteValue}

--- a/lib/nostr/bunker.ts
+++ b/lib/nostr/bunker.ts
@@ -66,6 +66,21 @@ const BUNKER_CALL_TIMEOUT_MS = 30_000;
 // for the round-trip + manual approval.
 const BUNKER_CONNECT_TIMEOUT_MS = 90_000;
 
+// Module-level memo: the last clientSk we generated for a given pasted
+// URI. The iOS Safari + Primal failure mode is that the user approves
+// in Primal, but iOS suspended the WebSocket while they were in the
+// other app, so the bunker's connect-ack is delivered to a dead
+// subscription and lost. nostr-tools' setupSubscription uses limit:0
+// with no `since`, so reconnecting can't replay the missed event.
+//
+// On retry within the same paste session we want to reuse the SAME
+// clientSk so the bunker recognizes us as the already-approved client
+// and acks immediately on the next connect request, rather than
+// re-prompting the user to approve a brand-new client. Keyed on the
+// sanitized URI so different pastes don't collide; cleared on
+// successful connect or when the user signs out/clears the textarea.
+const pendingClientSks = new Map<string, Uint8Array>();
+
 // Module-level health flag + listener set. Set when any wrapped call
 // times out or throws; cleared by restoreBunkerSigner on a successful
 // reconnect. The account-menu reconnect banner subscribes via
@@ -205,24 +220,33 @@ export async function connectBunkerFromUri(
         'On Primal: Settings → Keys → Remote Signer → copy the connection string.',
     );
   }
-  const clientSk = generateSecretKey();
+  // Reuse a previous attempt's clientSk on retry so an already-approved
+  // bunker doesn't re-prompt. See pendingClientSks comment above.
+  let clientSk = pendingClientSks.get(cleaned);
+  if (!clientSk) {
+    clientSk = generateSecretKey();
+    pendingClientSks.set(cleaned, clientSk);
+  }
   const signer = BunkerSigner.fromBunker(clientSk, pointer, {
     onauth: onAuthUrl,
   });
   // nostr-tools' connect() has no built-in timeout. Without this bound
   // a stalled relay or a never-approved auth_url leaves the UI on
   // "Connecting…" forever. Same for getPublicKey on the just-connected
-  // signer — it's another round-trip over the same transport.
+  // signer — it's another round-trip over the same transport. On
+  // failure, leave the clientSk in pendingClientSks so the user's next
+  // tap of Connect reuses the already-approved client identity.
   await withTimeout(
     signer.connect(),
     BUNKER_CONNECT_TIMEOUT_MS,
-    'connect (did you approve in your signer? on iOS, leave this tab in the foreground)',
+    'connect (approve in your signer, then tap Connect again — iOS may have suspended the relay link)',
   );
   const pubkey = await withTimeout(
     signer.getPublicKey(),
     BUNKER_CALL_TIMEOUT_MS,
     'get_public_key',
   );
+  pendingClientSks.delete(cleaned);
   return {
     inner: signer,
     pubkey,
@@ -230,6 +254,13 @@ export async function connectBunkerFromUri(
     uri: cleaned,
     clientSkHex: bytesToHex(clientSk),
   };
+}
+
+/** Drop any in-flight clientSk memo. Called when the user clears the
+ *  textarea or successfully completes a different login flow, so a
+ *  stale clientSk doesn't outlive the paste session. */
+export function clearPendingBunkerAttempts(): void {
+  pendingClientSks.clear();
 }
 
 /**

--- a/lib/nostr/bunker.ts
+++ b/lib/nostr/bunker.ts
@@ -57,6 +57,15 @@ const NOSTRCONNECT_TIMEOUT_MS = 120_000;
 // frozen UI.
 const BUNKER_CALL_TIMEOUT_MS = 30_000;
 
+// First-time `connect()` is the slow path — Primal/Clave/nsec.app may
+// surface an auth_url that the user has to tap, switch apps, approve,
+// then come back. nostr-tools' connect() has no timeout, so without
+// this bound the UI is stuck on "Connecting…" forever if the user
+// never approves, the relay drops, or iOS suspended Safari's WebSocket
+// while the user was in the signer app. 90s gives a comfortable margin
+// for the round-trip + manual approval.
+const BUNKER_CONNECT_TIMEOUT_MS = 90_000;
+
 // Module-level health flag + listener set. Set when any wrapped call
 // times out or throws; cleared by restoreBunkerSigner on a successful
 // reconnect. The account-menu reconnect banner subscribes via
@@ -152,34 +161,73 @@ function adaptToWindowNostr(signer: BunkerSigner): NonNullable<Window['nostr']> 
 }
 
 /**
+ * Normalize a pasted bunker URI so we tolerate the cruft mobile clipboards
+ * (and copy buttons in signers like Primal) tend to introduce:
+ *   - leading/trailing whitespace, newlines from copy-paste UI
+ *   - zero-width / BOM / NBSP characters that some "share sheet" flows
+ *     prepend on iOS
+ *   - uppercase hex in the bunker pubkey (NIP-46's reference regex is
+ *     strict-lowercase; signers don't always agree)
+ * Anything else is left intact so URL-encoded relay/secret values pass
+ * through untouched.
+ */
+function sanitizeBunkerUri(input: string): string {
+  // Strip whitespace + common invisible code points anywhere in the string.
+  // \s covers ASCII + unicode whitespace; the explicit characters cover
+  // ZWSP (200B), ZWNJ (200C), ZWJ (200D), BOM (FEFF), NBSP (00A0).
+  let cleaned = input.replace(/[\s​-‍﻿ ]/g, '');
+  const m = cleaned.match(/^bunker:\/\/([0-9a-fA-F]{64})(.*)$/);
+  if (m) {
+    cleaned = `bunker://${m[1].toLowerCase()}${m[2]}`;
+  }
+  return cleaned;
+}
+
+/**
  * PASTE flow. Parses a bunker:// URI (or NIP-05 like name@example.com),
  * generates a fresh client secret, connects, and returns the adapter.
  *
  * `onAuthUrl` fires if the bunker requires the user to open an approval
- * URL during connect (e.g. nsec.app's first-time flow).
+ * URL during connect (Primal, nsec.app, Clave first-time flows).
  */
 export async function connectBunkerFromUri(
   uri: string,
   onAuthUrl?: (url: string) => void,
 ): Promise<BunkerAdapter> {
-  const trimmed = uri.trim();
-  const pointer = await parseBunkerInput(trimmed);
+  const cleaned = sanitizeBunkerUri(uri);
+  if (!cleaned) {
+    throw new Error('Empty bunker URI. Paste a `bunker://…` URI from your remote signer.');
+  }
+  const pointer = await parseBunkerInput(cleaned);
   if (!pointer) {
     throw new Error(
-      'Could not parse bunker URI. Expected `bunker://…` or a NIP-05 like `name@domain`.',
+      'Could not parse bunker URI. Expected `bunker://<64-hex-pubkey>?relay=…` or a NIP-05 like `name@domain`. ' +
+        'On Primal: Settings → Keys → Remote Signer → copy the connection string.',
     );
   }
   const clientSk = generateSecretKey();
   const signer = BunkerSigner.fromBunker(clientSk, pointer, {
     onauth: onAuthUrl,
   });
-  await signer.connect();
-  const pubkey = await signer.getPublicKey();
+  // nostr-tools' connect() has no built-in timeout. Without this bound
+  // a stalled relay or a never-approved auth_url leaves the UI on
+  // "Connecting…" forever. Same for getPublicKey on the just-connected
+  // signer — it's another round-trip over the same transport.
+  await withTimeout(
+    signer.connect(),
+    BUNKER_CONNECT_TIMEOUT_MS,
+    'connect (did you approve in your signer? on iOS, leave this tab in the foreground)',
+  );
+  const pubkey = await withTimeout(
+    signer.getPublicKey(),
+    BUNKER_CALL_TIMEOUT_MS,
+    'get_public_key',
+  );
   return {
     inner: signer,
     pubkey,
     nostrApi: adaptToWindowNostr(signer),
-    uri: trimmed,
+    uri: cleaned,
     clientSkHex: bytesToHex(clientSk),
   };
 }
@@ -210,7 +258,11 @@ export function startNostrConnect(
       { onauth: onAuthUrl },
       NOSTRCONNECT_TIMEOUT_MS,
     );
-    const pubkey = await signer.getPublicKey();
+    const pubkey = await withTimeout(
+      signer.getPublicKey(),
+      BUNKER_CALL_TIMEOUT_MS,
+      'get_public_key',
+    );
     return {
       inner: signer,
       pubkey,
@@ -251,8 +303,12 @@ export async function restoreBunkerFromStorage(): Promise<BunkerAdapter | null> 
   }
   const clientSk = hexToBytes(cached.clientSk);
   const signer = BunkerSigner.fromBunker(clientSk, pointer);
-  await signer.connect();
-  const pubkey = await signer.getPublicKey();
+  await withTimeout(signer.connect(), BUNKER_CONNECT_TIMEOUT_MS, 'reconnect');
+  const pubkey = await withTimeout(
+    signer.getPublicKey(),
+    BUNKER_CALL_TIMEOUT_MS,
+    'get_public_key',
+  );
   return {
     inner: signer,
     pubkey,

--- a/lib/nostr/index.ts
+++ b/lib/nostr/index.ts
@@ -21,6 +21,7 @@ export { isLikelyAndroid, isLikelyIOS } from './amber';
 export {
   isBunkerStale,
   subscribeBunkerHealth,
+  clearPendingBunkerAttempts,
 } from './bunker';
 
 export { fetchProfile } from './profile';


### PR DESCRIPTION
The bunker paste flow could hang forever on iOS — Primal users who
copy a connection string and tap Connect see "Connecting…" with no
recovery if the signer never approves, the relay drops the
subscription, or Safari suspends the WebSocket while they switch to
Primal to approve. nostr-tools' connect() / getPublicKey() have no
built-in timeout, so the resolve handler sits unresolved indefinitely.

Wrap the first-time connect (and the matching restore-on-reload path)
in withTimeout — 90s for connect, 30s for getPublicKey — so the user
gets a real error message and can retry.

Sanitize the pasted URI: strip whitespace + zero-width / BOM / NBSP
characters that mobile clipboards sometimes inject, and lowercase the
bunker pubkey so a signer that emits uppercase hex doesn't fail
nostr-tools' strict-lowercase BUNKER_REGEX.

When the bunker sends auth_url, surface it as a magenta callout with
a real "Approve in signer" button and a "keep this tab open" hint
instead of a small underlined link that's easy to miss. Add a
Primal-specific instruction near the paste textarea.