### PR TITLE
Show pending and live items in episode lists

### DIFF
--- a/app/api/feed/route.ts
+++ b/app/api/feed/route.ts
@@ -1,17 +1,48 @@
 import { NextResponse } from 'next/server';
-import { getEpisodes, getPodcast } from '@/lib/pi';
+import { getEpisodes, getLiveItemsForFeed, getPodcast } from '@/lib/pi';
+import type { Episode } from '@/lib/types';
 import { getErrorMessage } from '@/lib/util';
+
+const LIVE_RANK: Record<NonNullable<Episode['liveStatus']>, number> = {
+  live: 0,
+  pending: 1,
+  ended: 2,
+};
 
 export async function GET(req: Request) {
   const { searchParams } = new URL(req.url);
   const id = Number(searchParams.get('id'));
   if (!id) return NextResponse.json({ error: 'missing id' }, { status: 400 });
   try {
-    const [podcast, episodes] = await Promise.all([getPodcast(id), getEpisodes(id, 50)]);
+    // Live-items lookup is best-effort — a PI hiccup on /episodes/live should
+    // not blank out the whole feed page.
+    const [podcast, episodes, liveItems] = await Promise.all([
+      getPodcast(id),
+      getEpisodes(id, 50),
+      getLiveItemsForFeed(id).catch(() => [] as Episode[]),
+    ]);
     if (!podcast) return NextResponse.json({ error: 'not found' }, { status: 404 });
-    // Episodes inherit the channel value block when they don't have their own.
-    const filled = episodes.map((e) => ({ ...e, value: e.value ?? podcast.value }));
-    return NextResponse.json({ podcast, episodes: filled });
+    // Merge: live items take precedence over a same-guid regular episode (they
+    // carry the liveStatus tag we want to surface).
+    const liveGuids = new Set(liveItems.map((e) => e.guid).filter(Boolean) as string[]);
+    const liveIds = new Set(liveItems.map((e) => e.id));
+    const regular = episodes.filter((e) => !(e.guid && liveGuids.has(e.guid)) && !liveIds.has(e.id));
+    const merged = [...liveItems, ...regular].map((e) => ({
+      ...e,
+      // Episodes inherit the channel value block when they don't have their own.
+      value: e.value ?? podcast.value,
+    }));
+    // Live first (live > pending > ended), then regular by datePublished desc.
+    merged.sort((a, b) => {
+      const ra = a.liveStatus ? LIVE_RANK[a.liveStatus] : 3;
+      const rb = b.liveStatus ? LIVE_RANK[b.liveStatus] : 3;
+      if (ra !== rb) return ra - rb;
+      if (a.liveStatus && b.liveStatus) {
+        return (b.liveStartTime ?? 0) - (a.liveStartTime ?? 0);
+      }
+      return (b.datePublished ?? 0) - (a.datePublished ?? 0);
+    });
+    return NextResponse.json({ podcast, episodes: merged });
   } catch (e) {
     return NextResponse.json({ error: getErrorMessage(e, 'feed fetch failed') }, { status: 500 });
   }

--- a/app/api/feed/route.ts
+++ b/app/api/feed/route.ts
@@ -3,10 +3,9 @@ import { getEpisodes, getLiveItemsForFeed, getPodcast } from '@/lib/pi';
 import type { Episode } from '@/lib/types';
 import { getErrorMessage } from '@/lib/util';
 
-const LIVE_RANK: Record<NonNullable<Episode['liveStatus']>, number> = {
+const LIVE_RANK: Partial<Record<NonNullable<Episode['liveStatus']>, number>> = {
   live: 0,
   pending: 1,
-  ended: 2,
 };
 
 export async function GET(req: Request) {
@@ -34,8 +33,8 @@ export async function GET(req: Request) {
     }));
     // Live first (live > pending > ended), then regular by datePublished desc.
     merged.sort((a, b) => {
-      const ra = a.liveStatus ? LIVE_RANK[a.liveStatus] : 3;
-      const rb = b.liveStatus ? LIVE_RANK[b.liveStatus] : 3;
+      const ra = a.liveStatus ? LIVE_RANK[a.liveStatus] ?? 3 : 3;
+      const rb = b.liveStatus ? LIVE_RANK[b.liveStatus] ?? 3 : 3;
       if (ra !== rb) return ra - rb;
       if (a.liveStatus && b.liveStatus) {
         return (b.liveStartTime ?? 0) - (a.liveStartTime ?? 0);

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -35,7 +35,7 @@ function LiveBadge({ status }: { status: NonNullable<Episode['liveStatus']> }) {
   if (status === 'pending') {
     return <span className="stamp text-bolt border-bolt/60">PENDING</span>;
   }
-  return <span className="stamp text-muted border-bone/20">ENDED</span>;
+  return null;
 }
 
 function FavHeart({ podcast }: { podcast: Podcast }) {
@@ -380,8 +380,8 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                 <div className="text-[11px] text-muted flex gap-2 mt-0.5">
                   {e.liveStatus && e.liveStartTime ? (
                     <span>
-                      {e.liveStatus === 'pending' ? 'starts ' : e.liveStatus === 'live' ? 'started ' : 'ended '}
-                      {fmtLiveTime(e.liveEndTime && e.liveStatus === 'ended' ? e.liveEndTime : e.liveStartTime)}
+                      {e.liveStatus === 'pending' ? 'starts ' : 'started '}
+                      {fmtLiveTime(e.liveStartTime)}
                     </span>
                   ) : (
                     e.datePublished && <span>{new Date(e.datePublished * 1000).toLocaleDateString()}</span>

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import type { Episode, Podcast, FavoritePodcast, ValueBlock } from '@/lib/types';
 import { useApp } from '@/lib/store';
 import { resolvePublishRelays, schedulePublishFavorites } from '@/lib/nostr';
@@ -331,11 +331,24 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
         <ValueBlockDetails value={data.podcast.value} />
       )}
       <ul className="divide-y divide-bone/10 max-h-[60vh] overflow-y-auto">
-        {data.episodes.map((e) => {
+        {data.episodes.map((e, idx) => {
           const playing = current?.episode.id === e.id;
+          const prev = idx > 0 ? data.episodes[idx - 1] : null;
+          const isFirstLive = !!e.liveStatus && (!prev || !prev.liveStatus);
+          const isFirstRegular = !e.liveStatus && !!prev?.liveStatus;
           return (
+            <Fragment key={e.id}>
+              {isFirstLive && (
+                <li className="text-[10px] uppercase tracking-[0.18em] text-muted pt-3 pb-1 border-b-0">
+                  Live &amp; upcoming
+                </li>
+              )}
+              {isFirstRegular && (
+                <li className="text-[10px] uppercase tracking-[0.18em] text-muted pt-4 pb-1 border-b-0">
+                  Episodes
+                </li>
+              )}
             <li
-              key={e.id}
               className={`flex gap-3 py-3 cursor-pointer group transition ${
                 playing ? 'bg-bolt/10' : 'hover:bg-bone/5'
               }`}
@@ -378,6 +391,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                 </div>
               </div>
             </li>
+            </Fragment>
           );
         })}
       </ul>

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -17,6 +17,27 @@ function fmtDuration(t: number) {
   return `${m}:${s}`;
 }
 
+function fmtLiveTime(unixSec: number) {
+  const d = new Date(unixSec * 1000);
+  const today = new Date();
+  const sameDay = d.toDateString() === today.toDateString();
+  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  if (sameDay) return time;
+  return `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} ${time}`;
+}
+
+function LiveBadge({ status }: { status: NonNullable<Episode['liveStatus']> }) {
+  if (status === 'live') {
+    return (
+      <span className="stamp text-nostr border-nostr/60 bg-nostr/10 animate-bolt">● LIVE</span>
+    );
+  }
+  if (status === 'pending') {
+    return <span className="stamp text-bolt border-bolt/60">PENDING</span>;
+  }
+  return <span className="stamp text-muted border-bone/20">ENDED</span>;
+}
+
 function FavHeart({ podcast }: { podcast: Podcast }) {
   const guid = podcast.podcastGuid;
   const isFav = useApp((s) => s.isFavorite(guid));
@@ -339,9 +360,19 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                 </div>
               </div>
               <div className="min-w-0 flex-1">
-                <div className="text-sm font-display leading-tight truncate">{e.title}</div>
+                <div className="flex items-center gap-2">
+                  {e.liveStatus && <LiveBadge status={e.liveStatus} />}
+                  <div className="text-sm font-display leading-tight truncate">{e.title}</div>
+                </div>
                 <div className="text-[11px] text-muted flex gap-2 mt-0.5">
-                  {e.datePublished && <span>{new Date(e.datePublished * 1000).toLocaleDateString()}</span>}
+                  {e.liveStatus && e.liveStartTime ? (
+                    <span>
+                      {e.liveStatus === 'pending' ? 'starts ' : e.liveStatus === 'live' ? 'started ' : 'ended '}
+                      {fmtLiveTime(e.liveEndTime && e.liveStatus === 'ended' ? e.liveEndTime : e.liveStartTime)}
+                    </span>
+                  ) : (
+                    e.datePublished && <span>{new Date(e.datePublished * 1000).toLocaleDateString()}</span>
+                  )}
                   {e.duration && <span>· {fmtDuration(e.duration)}</span>}
                   {e.value && <span className="text-bolt">· ⚡ V4V</span>}
                 </div>

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -257,6 +257,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
   });
   const [loading, setLoading] = useState(false);
   const [showBoostOpen, setShowBoostOpen] = useState(false);
+  const [liveBoostFor, setLiveBoostFor] = useState<Episode | null>(null);
   const [valueOpen, setValueOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const play = useApp((s) => s.play);
@@ -349,10 +350,13 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                 </li>
               )}
             <li
-              className={`flex gap-3 py-3 cursor-pointer group transition ${
-                playing ? 'bg-bolt/10' : 'hover:bg-bone/5'
-              }`}
-              onClick={() => data.podcast && play(e, data.podcast)}
+              className={`flex gap-3 py-3 group transition ${
+                playing ? 'bg-bolt/10' : e.liveStatus !== 'pending' ? 'hover:bg-bone/5' : ''
+              } ${e.liveStatus !== 'pending' ? 'cursor-pointer' : ''}`}
+              onClick={() => {
+                if (e.liveStatus === 'pending') return;
+                if (data.podcast) play(e, data.podcast);
+              }}
             >
               <div className="relative w-12 h-12 flex-shrink-0">
                 <PodcastCover
@@ -362,15 +366,17 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   seed={e.guid ?? String(e.id)}
                   className="w-full h-full border border-bone/40 group-hover:border-bolt text-base"
                 />
-                <div
-                  className={`absolute inset-0 grid place-items-center bg-ink/55 transition pointer-events-none ${
-                    playing
-                      ? 'opacity-100 text-bolt'
-                      : 'opacity-0 group-hover:opacity-100 text-bone group-hover:text-bolt'
-                  }`}
-                >
-                  {playing ? '❚❚' : '▶'}
-                </div>
+                {e.liveStatus !== 'pending' && (
+                  <div
+                    className={`absolute inset-0 grid place-items-center bg-ink/55 transition pointer-events-none ${
+                      playing
+                        ? 'opacity-100 text-bolt'
+                        : 'opacity-0 group-hover:opacity-100 text-bone group-hover:text-bolt'
+                    }`}
+                  >
+                    {playing ? '❚❚' : '▶'}
+                  </div>
+                )}
               </div>
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
@@ -390,6 +396,19 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   {e.value && <span className="text-bolt">· ⚡ V4V</span>}
                 </div>
               </div>
+              {e.liveStatus && (e.value ?? data.podcast?.value)?.recipients?.length ? (
+                <button
+                  type="button"
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    setLiveBoostFor(e);
+                  }}
+                  className="btn-bolt self-center flex-shrink-0"
+                  title="Boost this live item"
+                >
+                  <BoltIcon />
+                </button>
+              ) : null}
             </li>
             </Fragment>
           );
@@ -400,6 +419,15 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
         <PodcastNostrFeed
           podcastGuid={data.podcast.podcastGuid}
           podcastTitle={data.podcast.title}
+        />
+      )}
+
+      {liveBoostFor && data.podcast && (
+        <BoostModal
+          episode={liveBoostFor}
+          podcast={data.podcast}
+          positionSec={0}
+          onClose={() => setLiveBoostFor(null)}
         />
       )}
 

--- a/components/player.tsx
+++ b/components/player.tsx
@@ -34,6 +34,7 @@ export function Player() {
   if (!current) return null;
   const { episode, podcast } = current;
   const hasValue = !!episode.value && episode.value.recipients?.length > 0;
+  const isLive = episode.liveStatus === 'live';
 
   return (
     <>
@@ -52,22 +53,29 @@ export function Player() {
           <div className="min-w-0 flex-1">
             <div className="text-sm font-display leading-tight truncate">{episode.title}</div>
             <div className="text-[11px] text-muted truncate">{podcast.title}</div>
-            <div className="flex items-center gap-2 mt-1">
-              <span className="text-[10px] text-muted tabular-nums">{fmt(positionSec)}</span>
-              <input
-                type="range"
-                className="seek flex-1"
-                min={0}
-                max={duration || 0}
-                value={positionSec}
-                onChange={(e) => {
-                  const v = Number(e.target.value);
-                  if (audio.current) audio.current.currentTime = v;
-                  setPosition(v);
-                }}
-              />
-              <span className="text-[10px] text-muted tabular-nums">{fmt(duration)}</span>
-            </div>
+            {isLive ? (
+              <div className="flex items-center gap-2 mt-1">
+                <span className="stamp text-nostr border-nostr/60 bg-nostr/10 animate-bolt">● LIVE</span>
+                <span className="text-[10px] text-muted">streaming now</span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-[10px] text-muted tabular-nums">{fmt(positionSec)}</span>
+                <input
+                  type="range"
+                  className="seek flex-1"
+                  min={0}
+                  max={duration || 0}
+                  value={positionSec}
+                  onChange={(e) => {
+                    const v = Number(e.target.value);
+                    if (audio.current) audio.current.currentTime = v;
+                    setPosition(v);
+                  }}
+                />
+                <span className="text-[10px] text-muted tabular-nums">{fmt(duration)}</span>
+              </div>
+            )}
           </div>
           <div className="flex items-center gap-2">
             <button onClick={() => setPlaying(!isPlaying)} className="btn">
@@ -89,7 +97,7 @@ export function Player() {
         <BoostModal
           episode={episode}
           podcast={podcast}
-          positionSec={positionSec}
+          positionSec={isLive ? 0 : positionSec}
           onClose={() => setBoostOpen(false)}
         />
       )}

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -91,11 +91,8 @@ export async function getPodcastByGuid(guid: string): Promise<Podcast | null> {
   return buildPodcast(Array.isArray(f) ? f[0] : f);
 }
 
-export async function getEpisodes(feedId: number, max = 25): Promise<Episode[]> {
-  const data = await pi<any>(
-    `/episodes/byfeedid?id=${feedId}&max=${max}&fulltext`,
-  );
-  return (data.items ?? []).map((e: any) => ({
+function buildEpisode(e: any): Episode {
+  return {
     id: e.id,
     guid: e.guid,
     title: e.title,
@@ -110,5 +107,29 @@ export async function getEpisodes(feedId: number, max = 25): Promise<Episode[]> 
     feedImage: e.feedImage,
     podcastGuid: e.podcastGuid,
     value: normalizeValue(e.value),
-  }));
+  };
+}
+
+export async function getEpisodes(feedId: number, max = 25): Promise<Episode[]> {
+  const data = await pi<any>(
+    `/episodes/byfeedid?id=${feedId}&max=${max}&fulltext`,
+  );
+  return (data.items ?? []).map(buildEpisode);
+}
+
+// PI exposes liveItem records globally at /episodes/live. There is no per-feed
+// endpoint, so we pull a wide page and filter. Items carry a `status` field
+// ('live' | 'ended' | 'pending') plus startTime/endTime.
+export async function getLiveItemsForFeed(feedId: number): Promise<Episode[]> {
+  const data = await pi<any>(`/episodes/live?max=1000`);
+  const items = (data.items ?? []).filter((e: any) => Number(e.feedId) === feedId);
+  return items.map((e: any): Episode => {
+    const status = typeof e.status === 'string' ? e.status.toLowerCase() : undefined;
+    return {
+      ...buildEpisode(e),
+      liveStatus: status === 'pending' || status === 'live' || status === 'ended' ? status : undefined,
+      liveStartTime: typeof e.startTime === 'number' ? e.startTime : undefined,
+      liveEndTime: typeof e.endTime === 'number' ? e.endTime : undefined,
+    };
+  });
 }

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -118,18 +118,21 @@ export async function getEpisodes(feedId: number, max = 25): Promise<Episode[]> 
 }
 
 // PI exposes liveItem records globally at /episodes/live. There is no per-feed
-// endpoint, so we pull a wide page and filter. Items carry a `status` field
-// ('live' | 'ended' | 'pending') plus startTime/endTime.
+// endpoint, so we pull a wide page and filter. PI's status field can be
+// 'live' | 'pending' | 'ended'; we drop ended — old broadcasts shouldn't
+// crowd the top of the episode list.
 export async function getLiveItemsForFeed(feedId: number): Promise<Episode[]> {
   const data = await pi<any>(`/episodes/live?max=1000`);
-  const items = (data.items ?? []).filter((e: any) => Number(e.feedId) === feedId);
-  return items.map((e: any): Episode => {
+  const out: Episode[] = [];
+  for (const e of data.items ?? []) {
+    if (Number(e.feedId) !== feedId) continue;
     const status = typeof e.status === 'string' ? e.status.toLowerCase() : undefined;
-    return {
+    if (status !== 'live' && status !== 'pending') continue;
+    out.push({
       ...buildEpisode(e),
-      liveStatus: status === 'pending' || status === 'live' || status === 'ended' ? status : undefined,
+      liveStatus: status,
       liveStartTime: typeof e.startTime === 'number' ? e.startTime : undefined,
-      liveEndTime: typeof e.endTime === 'number' ? e.endTime : undefined,
-    };
-  });
+    });
+  }
+  return out;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -49,6 +49,13 @@ export interface Episode {
   feedImage?: string;
   podcastGuid?: string;
   value?: ValueBlock | null;
+  /** Podcast 2.0 <podcast:liveItem> status. Set on items returned by PI's
+   *  /episodes/live endpoint. Absent on regular episodes. */
+  liveStatus?: 'pending' | 'live' | 'ended';
+  /** Scheduled start, unix seconds. */
+  liveStartTime?: number;
+  /** Scheduled end, unix seconds. */
+  liveEndTime?: number;
 }
 
 export interface Boostagram {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -50,12 +50,11 @@ export interface Episode {
   podcastGuid?: string;
   value?: ValueBlock | null;
   /** Podcast 2.0 <podcast:liveItem> status. Set on items returned by PI's
-   *  /episodes/live endpoint. Absent on regular episodes. */
+   *  /episodes/live endpoint. We filter out 'ended' upstream, so only
+   *  'live' and 'pending' should ever reach the client. */
   liveStatus?: 'pending' | 'live' | 'ended';
   /** Scheduled start, unix seconds. */
   liveStartTime?: number;
-  /** Scheduled end, unix seconds. */
-  liveEndTime?: number;
 }
 
 export interface Boostagram {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "boostmebitch",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@breeztech/breez-sdk-spark": "^0.13.6",
         "@getalby/sdk": "^5.1.0",


### PR DESCRIPTION
The /api/feed route now fetches PI's /episodes/live alongside the regular
episode list, filters to the current feedId, and merges the two — live
items take precedence over a same-guid regular episode. Live > pending >
ended sort to the top, then regular episodes by publish date.

Each row carries the new optional liveStatus / liveStartTime / liveEndTime
fields; EpisodeList renders a status pill (LIVE pulses in nostr-magenta,
PENDING in bolt yellow, ENDED muted) and swaps the date line for a
relative start/end time on live rows.

PI failures on /episodes/live are swallowed so a degraded live endpoint
can't blank out the whole feed.