### PR TITLE
feat: add fullscreen now playing view

### DIFF
--- a/components/fullscreen-player.tsx
+++ b/components/fullscreen-player.tsx
@@ -1,0 +1,116 @@
+'use client';
+import { RefObject } from 'react';
+import { useApp } from '@/lib/store';
+import { BoltIcon } from './icons';
+import { PodcastCover } from './podcast-cover';
+
+function fmt(t: number) {
+  if (!isFinite(t)) return '0:00';
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  const s = Math.floor(t % 60).toString().padStart(2, '0');
+  if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${s}`;
+  return `${m}:${s}`;
+}
+
+export function FullscreenPlayer({
+  open,
+  duration,
+  audioRef,
+  onClose,
+  onBoost,
+}: {
+  open: boolean;
+  duration: number;
+  audioRef: RefObject<HTMLAudioElement | null>;
+  onClose: () => void;
+  onBoost: () => void;
+}) {
+  const { current, isPlaying, setPlaying, positionSec, setPosition } = useApp();
+  if (!current) return null;
+
+  const { episode, podcast } = current;
+  const isLive = episode.liveStatus === 'live';
+  const hasValue = !!episode.value && episode.value.recipients?.length > 0;
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 flex flex-col bg-ink transition-transform duration-300 ease-in-out ${open ? 'translate-y-0' : 'translate-y-full pointer-events-none'}`}
+      style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
+      {/* Top bar */}
+      <div className="flex items-center justify-between px-5 pt-4 pb-2 flex-shrink-0">
+        <span className="text-[11px] text-muted uppercase tracking-widest">Now Playing</span>
+        <button onClick={onClose} className="btn-ghost px-2 py-1 text-base leading-none" aria-label="Close fullscreen player">
+          ✕
+        </button>
+      </div>
+
+      {/* Artwork — fills remaining vertical space, centered */}
+      <div className="flex-1 flex items-center justify-center px-10 min-h-0 py-4">
+        <div className="w-full max-w-sm aspect-square">
+          <PodcastCover
+            image={episode.image ?? podcast.image}
+            artwork={podcast.artwork}
+            title={podcast.title}
+            seed={podcast.id?.toString()}
+            className="w-full h-full rounded-xl border border-bone/10 shadow-2xl"
+          />
+        </div>
+      </div>
+
+      {/* Metadata */}
+      <div className="px-8 text-center flex-shrink-0">
+        <div className="font-display text-xl leading-snug line-clamp-2">{episode.title}</div>
+        <div className="text-sm text-muted mt-1 truncate">{podcast.title}</div>
+      </div>
+
+      {/* Playback controls */}
+      <div className="px-8 pt-6 pb-8 flex flex-col gap-5 flex-shrink-0 w-full max-w-sm mx-auto">
+        {isLive ? (
+          <div className="flex items-center justify-center gap-2">
+            <span className="stamp text-nostr border-nostr/60 bg-nostr/10 animate-bolt">● LIVE</span>
+            <span className="text-xs text-muted">streaming now</span>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1.5">
+            <input
+              type="range"
+              className="seek w-full"
+              min={0}
+              max={duration || 0}
+              value={positionSec}
+              onChange={(e) => {
+                const v = Number(e.target.value);
+                if (audioRef.current) audioRef.current.currentTime = v;
+                setPosition(v);
+              }}
+            />
+            <div className="flex justify-between text-[11px] text-muted tabular-nums">
+              <span>{fmt(positionSec)}</span>
+              <span>{fmt(duration)}</span>
+            </div>
+          </div>
+        )}
+
+        <div className="flex items-center justify-center gap-4">
+          <button
+            onClick={() => setPlaying(!isPlaying)}
+            className="btn text-2xl w-14 h-14 flex items-center justify-center"
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+          >
+            {isPlaying ? '❚❚' : '▶'}
+          </button>
+          <button
+            onClick={onBoost}
+            disabled={!hasValue}
+            className="btn-bolt disabled:opacity-40 disabled:cursor-not-allowed"
+            title={hasValue ? 'Send a boost' : 'Episode has no value block'}
+          >
+            <BoltIcon /> BOOST
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/player.tsx
+++ b/components/player.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useApp } from '@/lib/store';
 import { BoostModal } from './boost-modal';
 import { BoltIcon } from './icons';
+import { FullscreenPlayer } from './fullscreen-player';
 
 function fmt(t: number) {
   if (!isFinite(t)) return '0:00';
@@ -18,6 +19,7 @@ export function Player() {
   const audio = useRef<HTMLAudioElement | null>(null);
   const [duration, setDuration] = useState(0);
   const [boostOpen, setBoostOpen] = useState(false);
+  const [fullscreenOpen, setFullscreenOpen] = useState(false);
 
   useEffect(() => {
     if (!audio.current || !current) return;
@@ -38,7 +40,12 @@ export function Player() {
 
   return (
     <>
-      <div className="fixed bottom-0 left-0 right-0 z-30 bg-ink/95 backdrop-blur border-t border-bolt/40 pb-[env(safe-area-inset-bottom)]">
+      <div
+        className="fixed bottom-0 left-0 right-0 z-30 bg-ink/95 backdrop-blur border-t border-bolt/40 pb-[env(safe-area-inset-bottom)] cursor-pointer"
+        onClick={() => setFullscreenOpen(true)}
+        role="button"
+        aria-label="Open fullscreen player"
+      >
         <audio
           ref={audio}
           onTimeUpdate={(e) => setPosition(e.currentTarget.currentTime)}
@@ -59,7 +66,7 @@ export function Player() {
                 <span className="text-[10px] text-muted">streaming now</span>
               </div>
             ) : (
-              <div className="flex items-center gap-2 mt-1">
+              <div className="flex items-center gap-2 mt-1" onClick={(e) => e.stopPropagation()}>
                 <span className="text-[10px] text-muted tabular-nums">{fmt(positionSec)}</span>
                 <input
                   type="range"
@@ -77,7 +84,7 @@ export function Player() {
               </div>
             )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
             <button onClick={() => setPlaying(!isPlaying)} className="btn">
               {isPlaying ? '❚❚' : '▶'}
             </button>
@@ -92,6 +99,14 @@ export function Player() {
           </div>
         </div>
       </div>
+
+      <FullscreenPlayer
+        open={fullscreenOpen}
+        duration={duration}
+        audioRef={audio}
+        onClose={() => setFullscreenOpen(false)}
+        onBoost={() => { setBoostOpen(true); setFullscreenOpen(false); }}
+      />
 
       {boostOpen && hasValue && (
         <BoostModal


### PR DESCRIPTION
Tap anywhere on the mini player bar to expand into a fullscreen now-playing
overlay. Shows large episode artwork, title, podcast name, full seek bar with
timestamps, play/pause, and a BOOST button. Slides up from the bottom with a
300ms CSS transition. Controls on the mini bar still work without opening
fullscreen (stopPropagation on seek row and buttons row).

https://claude.ai/code/session_01MD4h9WwoaJASLDVHgxqmih