### PR TITLE
Add Boost All Tracks feature (MOAB branch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ All three sub-cards (NWC, Spark, WebLN) render unconditionally — each flips in
 
 Sub-cards (each its own component): `nwc-wallet.tsx`, `spark-wallet.tsx`, `webln-wallet.tsx`. State changes propagate via `subscribeNwc()` + `subscribeSpark()`; the modal `setTick`s on either to flip between modes without remount.
 
-**Boost modal rail picker.** When 2+ rails are available, `components/boost-modal/index.tsx` renders a small "Pay via [NWC] [Spark] [WebLN]" pill row above the AmountInput so the user can override `pickRail()`'s default per-boost. Single-rail users never see it. The picker subscribes to `subscribeNwc`/`subscribeSpark` so enabling a rail mid-modal flips the row in place. WebLN doesn't have its own subscribe (the extension is either injected at load or it isn't), so we read `hasWebln()` on each render. The `!rail` "no wallet connected" hint still renders below the picker as a fallback for the zero-rail case.
+**Boost modal rail picker.** Single-boost `BoostModal` picks a rail silently via `pickRail()` (NWC > Spark > WebLN priority); the only mid-modal feedback is the "no wallet connected" hint when `!rail`. The visible "Pay via [NWC] [Spark] [WebLN]" pill row lives in `BoostAllModal` (`components/boost-all-modal.tsx`) — see the boost-all section below. Both modals subscribe to `subscribeNwc`/`subscribeSpark` so a wallet connected mid-modal updates `rail` without remount. WebLN doesn't have its own subscribe (the extension is either injected at load or it isn't), so `hasWebln()` is read on each render.
 
 `<BunkerHealthBanner>` still sits at the top of `<AccountMenu>` (not the wallet modal), since it's signer health, not wallet health.
 
@@ -167,6 +167,34 @@ Mnemonic is published encrypt-to-self as kind:30078 (`lib/nostr/wallet-backup.ts
 - Auto-formatted note body skips the `📻 <episode>` line and the `podcast:item:guid:` `i`-tag.
 
 The "⚡ BOOST" button on the `EpisodeList` header opens this mode (gated on `podcast.value.recipients.length > 0`). The per-episode boost path in `Player` is unchanged.
+
+## Boost-all tracks (valueTimeSplits)
+
+Music podcasts (Homegrown Hits, Lightning Thrashes, etc.) tag each track in their RSS with a `<podcast:valueTimeSplit>` block — a startTime/duration window plus a `<podcast:remoteItem feedGuid="…" itemGuid="…" />` pointing at the track's own album feed. PI surfaces these as **`e.timesplits[]`** (flat top-level array on the episode object, NOT nested under `e.value.valueTimeSplits` despite what the field name suggests). Each entry has `feedGuid`/`itemGuid`/`medium` directly — `parseRawValueTimeSplits` in `lib/pi.ts` maps the flat shape to the consumer-facing nested `ValueTimeSplit.remoteItem`.
+
+The `⚡ BOOST N TRACKS` button on each episode row in `components/lists.tsx` opens `<BoostAllModal>` (`components/boost-all-modal.tsx`). Sequential per-track sends, not parallel.
+
+**Resolution pipeline** (`/api/value-splits` → `lib/pi.ts:resolveValueTimeSplits`):
+
+1. **Probe-first-then-batch.** Try the first resolvable split synchronously. If it throws, return the whole batch unresolved instead of hammering PI when it's degraded. The remaining splits fan out in parallel with per-call try/catch.
+2. **PI's `/episodes/byguid` requires `podcastguid`** (lowercase param name — `feedGuid`/`feedid` are silently rejected with "This call requires either a valid feedid, feedurl or podcastguid argument").
+3. **Fallback to RSS chain** (`lib/musicl-resolver.ts:resolveRemoteItemFromRss`) when PI returns "Episode not found". Server-side, two cases:
+   - feedGuid is an album feed → find `<item>` with matching `<guid>`, extract `<podcast:value>` (or fall back to channel-level value).
+   - feedGuid is a publisher feed (`<podcast:medium>publisher</podcast:medium>`) → walk `<podcast:remoteItem feedUrl="…">` entries, fetch each album feed in parallel, return the first match.
+   5-min in-memory cache keyed on feed URL. 5s `AbortSignal.timeout` per fetch. Without this fallback, ~50% of music-podcast tracks fail to resolve because PI doesn't index every album feed.
+
+**Modal-side filtering.** The modal drops splits whose remote items couldn't be resolved to a value block. Header reads `Tracks (N of M — K unresolved)` when there's a gap. Remaining gaps are usually host-RSS authoring problems (stale feedGuid, no feedUrl hint, feed not in PI) and are unrecoverable from the client.
+
+**Per-track payment loop** (`BoostAllModal.go()`):
+
+1. **Two legs per track.** Each track sends `floor(sats × remotePercentage / 100)` to its own value block recipients (track artists). The (100 − remotePercentage) remainder fires as a SEPARATE host-share leg to `episode.value` (or `podcast.value`) immediately after, **per-track, not aggregated**. Both legs carry the same `remote_feed_guid`/`remote_item_guid` so the show host's Helipad can correlate which track triggered each share. Default `remotePercentage` = 100 (no host leg).
+2. **Boostagram shape.** Primary fields (`podcast`, `feedID`, `episode`, `episode_guid`) = HOST episode. `remote_feed_guid`/`remote_item_guid` = the TRACK. Mirrors `BoostModal`'s convention so recipient artists see the listener's host context, not mangled track-as-podcast metadata.
+3. **Each successful leg logs its own `StoredBoost`** to `bmb:boosts:<npub>` so the user's local sent-boost feed reflects every payment.
+4. **StrictMode guard.** `cancelled.current` ref is **reset to `false` on mount AND set to `true` on unmount**. Without the mount-side reset, dev StrictMode's mount → unmount → mount cycle leaves the ref stuck at `true` and the loop bails on the first iteration with no Lightning traffic at all (silent failure mode that took an HAR dump to diagnose).
+5. **Confetti on success** (mirrors `BoostModal`'s celebration) when at least one track pays.
+6. **Single Nostr summary note.** When `shareNostr` is on and at least one track paid, fires ONE kind:1 note via `publishBoostNote` with `contentOverride` listing every successful track title (no truncation). NOT one note per track.
+
+**Rail picker** (mid-modal wallet connect support). Unlike `BoostModal` which picks rail silently via `pickRail()`, `BoostAllModal` renders a "Pay via [NWC] [Spark] [WebLN]" pill row when 2+ rails are available. Computed inline (no `useMemo`) so the existing `subscribeNwc`/`subscribeSpark` re-render path lets newly-connected wallets appear without remount.
 
 ## Boost flow invariants
 

--- a/app/api/value-splits/route.ts
+++ b/app/api/value-splits/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getEpisodes, resolveValueTimeSplits } from '@/lib/pi';
+import { getErrorMessage } from '@/lib/util';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const feedId = Number(searchParams.get('feedId'));
+  const episodeId = Number(searchParams.get('episodeId'));
+  if (!feedId || !episodeId) {
+    return NextResponse.json({ error: 'missing feedId / episodeId' }, { status: 400 });
+  }
+  try {
+    const episodes = await getEpisodes(feedId, 50);
+    const episode = episodes.find((e) => e.id === episodeId);
+    if (!episode) return NextResponse.json({ error: 'episode not found' }, { status: 404 });
+    const raw = episode.valueTimeSplits ?? [];
+    if (!raw.length) return NextResponse.json({ splits: [] });
+    const splits = await resolveValueTimeSplits(raw);
+    return NextResponse.json(
+      { splits },
+      { headers: { 'Cache-Control': 'public, max-age=3600' } },
+    );
+  } catch (e) {
+    return NextResponse.json(
+      { error: getErrorMessage(e, 'value-splits fetch failed') },
+      { status: 500 },
+    );
+  }
+}

--- a/components/boost-all-modal.tsx
+++ b/components/boost-all-modal.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Episode, Podcast, Boostagram, ValueTimeSplit, StoredBoost } from '@/lib/types';
 import { useApp } from '@/lib/store';
 import { sendBoost, pickRail, type Rail } from '@/lib/v4v/boost';
@@ -41,6 +41,13 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
   const [done, setDone] = useState(false);
   const [progress, setProgress] = useState<TrackProgress[]>([]);
 
+  // Set on unmount so the in-flight loop bails before firing more sends or
+  // calling setState on an unmounted component. The current track's send
+  // can't be aborted (Lightning is fire-and-forget), but its storage.boosts
+  // log still records — money moved, the user should see it later.
+  const cancelled = useRef(false);
+  useEffect(() => () => { cancelled.current = true; }, []);
+
   // Sync rail if wallet connects/disconnects while modal is open.
   useEffect(() => {
     const bump = () => setRail(pickRail());
@@ -79,13 +86,13 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
       .catch(() => setLoadState('error'));
   }, [episode.feedId, episode.id]);
 
-  const availableRails = useMemo(() => {
-    const rails: Rail[] = [];
-    if (hasNwc()) rails.push('nwc');
-    if (hasSpark()) rails.push('spark');
-    if (hasWebln()) rails.push('webln');
-    return rails;
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  // Recomputed every render so newly-connected wallets show up in the picker
+  // without a remount. The subscribeNwc/subscribeSpark useEffect above already
+  // triggers a re-render via setRail(pickRail()) when state changes.
+  const availableRails: Rail[] = [];
+  if (hasNwc()) availableRails.push('nwc');
+  if (hasSpark()) availableRails.push('spark');
+  if (hasWebln()) availableRails.push('webln');
 
   const total = sats * splits.length;
 
@@ -97,6 +104,7 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
     setProgress([]);
 
     for (let i = 0; i < splits.length; i++) {
+      if (cancelled.current) return;
       const split = splits[i];
       // Boostagram shape for valueTimeSplits: HOST episode in primary fields
       // (the album/playlist the listener is playing), TRACK in remote_*. The
@@ -154,8 +162,10 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
           storage.boosts.add(identity?.npub, stored);
           bumpBoosts();
         }
+        if (cancelled.current) return;
         setProgress((prev) => [...prev, { index: i, ok }]);
       } catch (e) {
+        if (cancelled.current) return;
         setProgress((prev) => [
           ...prev,
           { index: i, ok: false, error: getErrorMessage(e, 'boost failed') },

--- a/components/boost-all-modal.tsx
+++ b/components/boost-all-modal.tsx
@@ -1,17 +1,19 @@
 'use client';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Episode, Podcast, Boostagram, ValueTimeSplit, StoredBoost } from '@/lib/types';
 import { useApp } from '@/lib/store';
 import { sendBoost, pickRail, type Rail } from '@/lib/v4v/boost';
 import { hasNwc, subscribeNwc } from '@/lib/v4v/nwc';
 import { hasSpark, subscribeSpark } from '@/lib/v4v/spark';
 import { hasWebln } from '@/lib/v4v/webln';
+import { publishBoostNote, resolvePublishRelays } from '@/lib/nostr';
 import { storage } from '@/lib/storage';
 import { getErrorMessage } from '@/lib/util';
 import { BoltIcon } from './icons';
 import { AmountInput, MIN_BOOST_SATS } from './boost-modal/amount-input';
 import { MessageInput } from './boost-modal/message-input';
 import { SenderName } from './boost-modal/sender-name';
+import { PublishStatus, type PublishState } from './boost-modal/publish-status';
 import { PodcastCover } from './podcast-cover';
 
 interface Props {
@@ -40,6 +42,15 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
   const [running, setRunning] = useState(false);
   const [done, setDone] = useState(false);
   const [progress, setProgress] = useState<TrackProgress[]>([]);
+
+  const [shareNostr, setShareNostr] = useState(() => storage.shareNostr.get());
+  const [pubState, setPubState] = useState<PublishState>({ kind: 'idle' });
+  const relays = useMemo(() => resolvePublishRelays(identity), [identity]);
+
+  function handleShareNostrChange(v: boolean) {
+    setShareNostr(v);
+    storage.shareNostr.set(v);
+  }
 
   // Set on unmount so the in-flight loop bails before firing more sends or
   // calling setState on an unmounted component. The current track's send
@@ -103,6 +114,11 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
     setRunning(true);
     setProgress([]);
 
+    // Local success tracker — `progress` state has stale-closure issues
+    // across awaits, and we need the final list immediately for the
+    // post-loop Nostr publish.
+    const successfulIdx: number[] = [];
+
     for (let i = 0; i < splits.length; i++) {
       if (cancelled.current) return;
       const split = splits[i];
@@ -161,6 +177,7 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
           };
           storage.boosts.add(identity?.npub, stored);
           bumpBoosts();
+          successfulIdx.push(i);
         }
         if (cancelled.current) return;
         setProgress((prev) => [...prev, { index: i, ok }]);
@@ -175,6 +192,66 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
 
     setRunning(false);
     setDone(true);
+
+    // Single summary note covering all successful tracks. Gated on the
+    // share-on-Nostr toggle and at least one paid leg — matches BoostModal's
+    // "don't pollute the network with failed-only boosts" rule.
+    if (cancelled.current) return;
+    if (!shareNostr || !identity || successfulIdx.length === 0) return;
+
+    const totalSats = successfulIdx.length * sats;
+    const trackList = successfulIdx
+      .map((i) => splits[i].title)
+      .filter((t): t is string => !!t)
+      .slice(0, 8);
+    const moreCount = successfulIdx.length - trackList.length;
+
+    const summaryBoostagram: Boostagram = {
+      app_name: 'BoostMeBitch',
+      app_version: '0.1.0',
+      podcast: podcast.title,
+      feedID: podcast.id,
+      url: podcast.url,
+      episode: episode.title,
+      itemID: episode.id,
+      episode_guid: episode.guid,
+      ts: 0,
+      value_msat_total: totalSats * 1000,
+      message: msg || undefined,
+      sender_name: name || undefined,
+      sender_id: identity.pubkey,
+      action: 'boost',
+      uuid: crypto.randomUUID(),
+    };
+
+    const lines: string[] = ['⚡ Boost ⚡', ''];
+    if (msg.trim()) lines.push(msg.trim(), '');
+    lines.push(
+      `Boosted ${successfulIdx.length} track${successfulIdx.length === 1 ? '' : 's'} on ${podcast.title} for ${totalSats} sats`,
+    );
+    if (trackList.length) {
+      lines.push('');
+      for (const t of trackList) lines.push(`• ${t}`);
+      if (moreCount > 0) lines.push(`…and ${moreCount} more`);
+    }
+    const contentOverride = lines.join('\n');
+
+    setPubState({ kind: 'publishing' });
+    try {
+      const note = await publishBoostNote({
+        podcast,
+        episode,
+        boostagram: summaryBoostagram,
+        results: [],
+        relays,
+        contentOverride,
+      });
+      if (cancelled.current) return;
+      setPubState({ kind: 'done', note });
+    } catch (e) {
+      if (cancelled.current) return;
+      setPubState({ kind: 'error', message: getErrorMessage(e, 'publish failed') });
+    }
   }
 
   const RAIL_LABELS: Record<Rail, string> = { nwc: 'NWC', spark: 'Spark', webln: 'WebLN' };
@@ -275,6 +352,32 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
             <>
               <MessageInput value={msg} onChange={setMsg} />
               <SenderName value={name} onChange={setName} />
+              <label
+                className={`card flex items-start gap-3 p-3 cursor-pointer transition ${
+                  !identity ? 'opacity-40 cursor-not-allowed' : ''
+                } ${shareNostr && identity ? '!border-nostr/60' : ''}`}
+              >
+                <input
+                  type="checkbox"
+                  checked={shareNostr && !!identity}
+                  disabled={!identity}
+                  onChange={(e) => handleShareNostrChange(e.target.checked)}
+                  className="accent-nostr mt-0.5"
+                />
+                <div className="flex-1 text-xs">
+                  <div className="text-bone flex items-center gap-2">
+                    <span className={shareNostr && identity ? 'text-nostr' : 'text-muted'}>◆</span>
+                    {identity && !shareNostr
+                      ? 'Private boost — Lightning only'
+                      : 'Share boost on Nostr (one summary note)'}
+                  </div>
+                  {!identity && (
+                    <div className="text-muted mt-0.5 leading-relaxed">
+                      Sign in with Nostr to enable.
+                    </div>
+                  )}
+                </div>
+              </label>
             </>
           )}
 
@@ -283,6 +386,8 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
               {progress.filter((p) => p.ok).length} of {splits.length} tracks boosted successfully.
             </div>
           )}
+
+          <PublishStatus state={pubState} />
 
         </div>
 

--- a/components/boost-all-modal.tsx
+++ b/components/boost-all-modal.tsx
@@ -56,8 +56,14 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
   // calling setState on an unmounted component. The current track's send
   // can't be aborted (Lightning is fire-and-forget), but its storage.boosts
   // log still records — money moved, the user should see it later.
+  //
+  // Reset on mount so React 18 StrictMode's mount→unmount→mount cycle in dev
+  // doesn't leave cancelled=true permanently from the intermediate cleanup.
   const cancelled = useRef(false);
-  useEffect(() => () => { cancelled.current = true; }, []);
+  useEffect(() => {
+    cancelled.current = false;
+    return () => { cancelled.current = true; };
+  }, []);
 
   // Sync rail if wallet connects/disconnects while modal is open.
   useEffect(() => {

--- a/components/boost-all-modal.tsx
+++ b/components/boost-all-modal.tsx
@@ -1,0 +1,274 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import type { Episode, Podcast, Boostagram, ValueTimeSplit } from '@/lib/types';
+import { useApp } from '@/lib/store';
+import { sendBoost, pickRail, type Rail } from '@/lib/v4v/boost';
+import { hasNwc, subscribeNwc } from '@/lib/v4v/nwc';
+import { hasSpark, subscribeSpark } from '@/lib/v4v/spark';
+import { hasWebln } from '@/lib/v4v/webln';
+import { storage } from '@/lib/storage';
+import { getErrorMessage } from '@/lib/util';
+import { BoltIcon } from './icons';
+import { AmountInput, MIN_BOOST_SATS } from './boost-modal/amount-input';
+import { MessageInput } from './boost-modal/message-input';
+import { SenderName } from './boost-modal/sender-name';
+import { PodcastCover } from './podcast-cover';
+
+interface Props {
+  podcast: Podcast;
+  episode: Episode;
+  onClose: () => void;
+}
+
+interface TrackProgress {
+  index: number;
+  ok: boolean;
+  error?: string;
+}
+
+export function BoostAllModal({ podcast, episode, onClose }: Props) {
+  const identity = useApp((s) => s.identity);
+  const [sats, setSats] = useState(100);
+  const [msg, setMsg] = useState('');
+  const [name, setName] = useState('');
+  const [rail, setRail] = useState<Rail | null>(null);
+
+  const [splits, setSplits] = useState<ValueTimeSplit[]>([]);
+  const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error'>('loading');
+
+  const [running, setRunning] = useState(false);
+  const [done, setDone] = useState(false);
+  const [progress, setProgress] = useState<TrackProgress[]>([]);
+
+  // Sync rail if wallet connects/disconnects while modal is open.
+  useEffect(() => {
+    const bump = () => setRail(pickRail());
+    const unsubNwc = subscribeNwc(bump);
+    const unsubSpark = subscribeSpark(bump);
+    return () => { unsubNwc(); unsubSpark(); };
+  }, []);
+
+  useEffect(() => {
+    const pref = storage.railPref.get();
+    const prefAvailable =
+      (pref === 'nwc' && hasNwc())
+      || (pref === 'spark' && hasSpark())
+      || (pref === 'webln' && hasWebln());
+    setRail(prefAvailable ? pref : pickRail());
+    setName((cur) => {
+      if (cur) return cur;
+      const stored = storage.senderName.get();
+      if (stored) return stored;
+      return identity?.profile?.display_name || identity?.profile?.name || '';
+    });
+  }, [identity?.profile?.display_name, identity?.profile?.name]);
+
+  // Fetch resolved value splits for this episode.
+  useEffect(() => {
+    setLoadState('loading');
+    fetch(`/api/value-splits?feedId=${episode.feedId}&episodeId=${episode.id}`)
+      .then((r) => r.json())
+      .then((data) => {
+        const resolved = (data.splits as ValueTimeSplit[]).filter(
+          (s) => s.value?.recipients?.length,
+        );
+        setSplits(resolved);
+        setLoadState('ready');
+      })
+      .catch(() => setLoadState('error'));
+  }, [episode.feedId, episode.id]);
+
+  const availableRails = useMemo(() => {
+    const rails: Rail[] = [];
+    if (hasNwc()) rails.push('nwc');
+    if (hasSpark()) rails.push('spark');
+    if (hasWebln()) rails.push('webln');
+    return rails;
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const total = sats * splits.length;
+
+  async function go() {
+    if (!rail || !splits.length) return;
+    if (name) storage.senderName.set(name);
+
+    setRunning(true);
+    setProgress([]);
+
+    for (let i = 0; i < splits.length; i++) {
+      const split = splits[i];
+      const boostagram: Boostagram = {
+        app_name: 'BoostMeBitch',
+        app_version: '0.1.0',
+        podcast: split.title ?? episode.title,
+        feedID: split.feedId ?? episode.feedId,
+        episode: split.title,
+        episode_guid: split.episodeGuid,
+        remote_feed_guid: split.remoteItem?.feedGuid,
+        remote_item_guid: split.episodeGuid,
+        ts: 0,
+        value_msat_total: sats * 1000,
+        message: msg || undefined,
+        sender_name: name || undefined,
+        sender_id: identity?.pubkey,
+        action: 'boost',
+        uuid: crypto.randomUUID(),
+      };
+      try {
+        const results = await sendBoost({
+          value: split.value!,
+          totalSats: sats,
+          boostagram,
+          rail,
+        });
+        const ok = results.some((r) => r.ok);
+        setProgress((prev) => [...prev, { index: i, ok }]);
+      } catch (e) {
+        setProgress((prev) => [
+          ...prev,
+          { index: i, ok: false, error: getErrorMessage(e, 'boost failed') },
+        ]);
+      }
+    }
+
+    setRunning(false);
+    setDone(true);
+  }
+
+  const RAIL_LABELS: Record<Rail, string> = { nwc: 'NWC', spark: 'Spark', webln: 'WebLN' };
+
+  return (
+    <div className="fixed inset-0 z-40 bg-ink/85 backdrop-blur-sm flex items-center justify-center p-4">
+      <div className="card w-full max-w-xl bg-ink relative max-h-[92vh] overflow-y-auto">
+        <button
+          onClick={onClose}
+          className="absolute top-2 right-3 text-muted hover:text-bone text-lg z-10"
+          aria-label="Close"
+        >×</button>
+
+        <div className="p-5 border-b border-bone/15">
+          <div className="stamp text-bolt border-bolt/60 mb-2">⚡ BOOST ALL TRACKS</div>
+          <h3 className="font-display text-2xl leading-tight">{episode.title}</h3>
+          <p className="text-xs text-muted mt-1">{podcast.title}</p>
+        </div>
+
+        <div className="p-5 space-y-4">
+
+          {!rail && (
+            <div className="text-[11px] text-nostr/80">
+              No wallet connected — set one up in the account menu (top right).
+            </div>
+          )}
+
+          {availableRails.length >= 2 && (
+            <div>
+              <p className="text-[11px] uppercase tracking-widest text-muted mb-1.5">Pay via</p>
+              <div className="flex gap-2">
+                {availableRails.map((r) => (
+                  <button
+                    key={r}
+                    onClick={() => setRail(r)}
+                    className={`btn-ghost !px-3 text-xs ${rail === r ? '!border-bolt text-bolt' : ''}`}
+                  >
+                    {RAIL_LABELS[r]}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <AmountInput sats={sats} onChange={setSats} />
+
+          {loadState === 'loading' && (
+            <p className="text-muted text-sm">Loading tracks…</p>
+          )}
+          {loadState === 'error' && (
+            <p className="text-nostr/80 text-sm">Could not load track data. Try again later.</p>
+          )}
+          {loadState === 'ready' && splits.length === 0 && (
+            <p className="text-muted text-sm">No resolvable value blocks found for this episode.</p>
+          )}
+          {loadState === 'ready' && splits.length > 0 && (
+            <div>
+              <p className="text-[11px] uppercase tracking-widest text-muted mb-2">
+                Tracks ({splits.length})
+              </p>
+              <ul className="space-y-2">
+                {splits.map((split, i) => {
+                  const result = progress.find((p) => p.index === i);
+                  return (
+                    <li key={i} className="card p-3 flex items-center gap-3">
+                      <PodcastCover
+                        image={split.image}
+                        title={split.title ?? `Track ${i + 1}`}
+                        seed={split.remoteItem?.itemGuid ?? String(i)}
+                        className="w-10 h-10 flex-shrink-0 text-xs border border-bone/20"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium truncate">
+                          {split.title ?? `Track ${i + 1}`}
+                        </div>
+                        <div className="text-xs text-muted">
+                          {split.value?.recipients?.length ?? 0} recipient
+                          {(split.value?.recipients?.length ?? 0) !== 1 ? 's' : ''}
+                          {split.duration ? ` · ${Math.round(split.duration / 60)}m` : ''}
+                        </div>
+                      </div>
+                      {result && (
+                        <span className={result.ok ? 'text-bolt text-sm' : 'text-nostr/80 text-sm'}>
+                          {result.ok ? '✓' : '✗'}
+                        </span>
+                      )}
+                      {running && !result && i >= (progress.length) && (
+                        <span className="text-muted text-xs animate-pulse">…</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          {loadState === 'ready' && splits.length > 0 && (
+            <>
+              <MessageInput value={msg} onChange={setMsg} />
+              <SenderName value={name} onChange={setName} />
+            </>
+          )}
+
+          {done && (
+            <div className="text-sm text-muted">
+              {progress.filter((p) => p.ok).length} of {splits.length} tracks boosted successfully.
+            </div>
+          )}
+
+        </div>
+
+        <div className="flex justify-between items-center gap-3 p-5 border-t border-bone/15 sticky bottom-0 bg-ink">
+          <button onClick={onClose} className="btn-ghost">{done ? 'Close' : 'Cancel'}</button>
+          <div className="flex items-center gap-3">
+            {!done && loadState === 'ready' && splits.length > 0 && (
+              <>
+                {total > 0 && (
+                  <span className="text-bolt text-sm font-mono">
+                    {splits.length} × {sats} = {total} sats
+                  </span>
+                )}
+                <button
+                  onClick={go}
+                  disabled={running || !rail || sats < MIN_BOOST_SATS || splits.length === 0}
+                  className="btn-bolt disabled:opacity-40"
+                >
+                  <BoltIcon />
+                  {running
+                    ? `${progress.length}/${splits.length}…`
+                    : `Boost ${splits.length} tracks`}
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/boost-all-modal.tsx
+++ b/components/boost-all-modal.tsx
@@ -48,6 +48,7 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
   const [rail, setRail] = useState<Rail | null>(null);
 
   const [splits, setSplits] = useState<ValueTimeSplit[]>([]);
+  const [totalSplits, setTotalSplits] = useState(0);
   const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error'>('loading');
 
   const [running, setRunning] = useState(false);
@@ -105,10 +106,10 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
     fetch(`/api/value-splits?feedId=${episode.feedId}&episodeId=${episode.id}`)
       .then((r) => r.json())
       .then((data) => {
-        const resolved = (data.splits as ValueTimeSplit[]).filter(
-          (s) => s.value?.recipients?.length,
-        );
+        const all = (data.splits as ValueTimeSplit[]) ?? [];
+        const resolved = all.filter((s) => s.value?.recipients?.length);
         setSplits(resolved);
+        setTotalSplits(all.length);
         setLoadState('ready');
       })
       .catch(() => setLoadState('error'));
@@ -321,12 +322,17 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
             <p className="text-nostr/80 text-sm">Could not load track data. Try again later.</p>
           )}
           {loadState === 'ready' && splits.length === 0 && (
-            <p className="text-muted text-sm">No resolvable value blocks found for this episode.</p>
+            <p className="text-muted text-sm">
+              {totalSplits > 0
+                ? `${totalSplits} track${totalSplits === 1 ? '' : 's'} listed in the RSS feed, but Podcast Index couldn't resolve any of their value blocks.`
+                : 'No resolvable value blocks found for this episode.'}
+            </p>
           )}
           {loadState === 'ready' && splits.length > 0 && (
             <div>
               <p className="text-[11px] uppercase tracking-widest text-muted mb-2">
-                Tracks ({splits.length})
+                Tracks ({splits.length}
+                {totalSplits > splits.length && ` of ${totalSplits} — ${totalSplits - splits.length} unresolved`})
               </p>
               <ul className="space-y-2">
                 {splits.map((split, i) => {

--- a/components/boost-all-modal.tsx
+++ b/components/boost-all-modal.tsx
@@ -136,10 +136,21 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
     // across awaits, and we need the final list immediately for the
     // post-loop Nostr publish.
     const successfulIdx: number[] = [];
+    // Accumulate the host's share of each successful track per the spec's
+    // remotePercentage. Sent as a single show-level boost at the end so the
+    // user only ever sees one extra leg in their boost log instead of N
+    // tiny crumbs.
+    let hostShareSats = 0;
 
     for (let i = 0; i < splits.length; i++) {
       if (cancelled.current) return;
       const split = splits[i];
+      // Spec: remotePercentage is the share that goes to the remote (track)
+      // recipients; (100 − remotePercentage) goes to the host show.
+      // Default 100 (all to track) when missing.
+      const remotePct = Math.min(100, Math.max(0, split.remotePercentage ?? 100));
+      const trackSats = Math.floor((sats * remotePct) / 100);
+      const showLegSats = sats - trackSats;
       // Boostagram shape for valueTimeSplits: HOST episode in primary fields
       // (the album/playlist the listener is playing), TRACK in remote_*. The
       // recipient artist sees `podcast`/`episode` describing the listener's
@@ -156,7 +167,7 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
         remote_feed_guid: split.remoteItem?.feedGuid,
         remote_item_guid: split.remoteItem?.itemGuid,
         ts: 0,
-        value_msat_total: sats * 1000,
+        value_msat_total: trackSats * 1000,
         message: msg || undefined,
         sender_name: name || undefined,
         sender_id: identity?.pubkey,
@@ -164,13 +175,12 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
         uuid: crypto.randomUUID(),
       };
       try {
-        const results = await sendBoost({
-          value: split.value!,
-          totalSats: sats,
-          boostagram,
-          rail,
-        });
-        const ok = results.some((r) => r.ok);
+        // trackSats can floor to 0 with very small per-track sats; in that
+        // case we treat the entire amount as host share (covered after loop).
+        const results = trackSats > 0
+          ? await sendBoost({ value: split.value!, totalSats: trackSats, boostagram, rail })
+          : [];
+        const ok = trackSats > 0 && results.some((r) => r.ok);
         if (ok) {
           const stored: StoredBoost = {
             uuid: boostagram.uuid!,
@@ -181,7 +191,7 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
             podcastImage: split.image ?? episode.image ?? podcast.image,
             episodeTitle: episode.title,
             episodeGuid: episode.guid,
-            sats,
+            sats: trackSats,
             message: msg || undefined,
             senderName: name || undefined,
             legs: results.map((r) => ({
@@ -196,6 +206,10 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
           storage.boosts.add(identity?.npub, stored);
           bumpBoosts();
           successfulIdx.push(i);
+          hostShareSats += showLegSats;
+        } else if (trackSats === 0) {
+          // No track payment to skip — full amount lands on host
+          hostShareSats += sats;
         }
         if (cancelled.current) return;
         setProgress((prev) => [...prev, { index: i, ok }]);
@@ -205,6 +219,66 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
           ...prev,
           { index: i, ok: false, error: getErrorMessage(e, 'boost failed') },
         ]);
+      }
+    }
+
+    // Spec: the host show gets (100 − remotePercentage)% of each track. We
+    // accumulated the floored remainder across all tracks; send it now as
+    // one show-level leg so the host's recipients aren't shorted entirely.
+    // Falls back to podcast.value when the episode itself has no value block.
+    const hostValue = episode.value ?? podcast.value;
+    if (hostShareSats > 0 && hostValue?.recipients?.length && !cancelled.current) {
+      const hostBoostagram: Boostagram = {
+        app_name: 'BoostMeBitch',
+        app_version: '0.1.0',
+        podcast: podcast.title,
+        feedID: podcast.id,
+        url: podcast.url,
+        episode: episode.title,
+        itemID: episode.id,
+        episode_guid: episode.guid,
+        ts: 0,
+        value_msat_total: hostShareSats * 1000,
+        message: msg || undefined,
+        sender_name: name || undefined,
+        sender_id: identity?.pubkey,
+        action: 'boost',
+        uuid: crypto.randomUUID(),
+      };
+      try {
+        const hostResults = await sendBoost({
+          value: hostValue,
+          totalSats: hostShareSats,
+          boostagram: hostBoostagram,
+          rail,
+        });
+        if (hostResults.some((r) => r.ok)) {
+          const stored: StoredBoost = {
+            uuid: hostBoostagram.uuid!,
+            ts: Date.now(),
+            podcastTitle: podcast.title,
+            podcastId: podcast.id,
+            podcastGuid: podcast.podcastGuid,
+            podcastImage: episode.image ?? podcast.image,
+            episodeTitle: episode.title,
+            episodeGuid: episode.guid,
+            sats: hostShareSats,
+            message: msg || undefined,
+            senderName: name || undefined,
+            legs: hostResults.map((r) => ({
+              recipient: r.recipient.address,
+              recipientName: r.recipient.name,
+              sats: r.sats,
+              ok: r.ok,
+              error: r.error,
+              boostboxUrl: r.boostboxUrl,
+            })),
+          };
+          storage.boosts.add(identity?.npub, stored);
+          bumpBoosts();
+        }
+      } catch {
+        // Host leg failure is non-fatal — track legs already paid out.
       }
     }
 

--- a/components/boost-all-modal.tsx
+++ b/components/boost-all-modal.tsx
@@ -136,11 +136,8 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
     // across awaits, and we need the final list immediately for the
     // post-loop Nostr publish.
     const successfulIdx: number[] = [];
-    // Accumulate the host's share of each successful track per the spec's
-    // remotePercentage. Sent as a single show-level boost at the end so the
-    // user only ever sees one extra leg in their boost log instead of N
-    // tiny crumbs.
-    let hostShareSats = 0;
+    // The host show's value block (preferred per-episode, falls back to feed-level).
+    const hostValue = episode.value ?? podcast.value;
 
     for (let i = 0; i < splits.length; i++) {
       if (cancelled.current) return;
@@ -155,7 +152,7 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
       // (the album/playlist the listener is playing), TRACK in remote_*. The
       // recipient artist sees `podcast`/`episode` describing the listener's
       // context and `remote_*` identifying which track triggered the boost.
-      const boostagram: Boostagram = {
+      const trackBoostagram: Boostagram = {
         app_name: 'BoostMeBitch',
         app_version: '0.1.0',
         podcast: podcast.title,
@@ -174,112 +171,115 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
         action: 'boost',
         uuid: crypto.randomUUID(),
       };
+      let trackOk = false;
       try {
-        // trackSats can floor to 0 with very small per-track sats; in that
-        // case we treat the entire amount as host share (covered after loop).
-        const results = trackSats > 0
-          ? await sendBoost({ value: split.value!, totalSats: trackSats, boostagram, rail })
-          : [];
-        const ok = trackSats > 0 && results.some((r) => r.ok);
-        if (ok) {
-          const stored: StoredBoost = {
-            uuid: boostagram.uuid!,
-            ts: Date.now(),
-            podcastTitle: podcast.title,
-            podcastId: podcast.id,
-            podcastGuid: podcast.podcastGuid,
-            podcastImage: split.image ?? episode.image ?? podcast.image,
-            episodeTitle: episode.title,
-            episodeGuid: episode.guid,
-            sats: trackSats,
-            message: msg || undefined,
-            senderName: name || undefined,
-            legs: results.map((r) => ({
-              recipient: r.recipient.address,
-              recipientName: r.recipient.name,
-              sats: r.sats,
-              ok: r.ok,
-              error: r.error,
-              boostboxUrl: r.boostboxUrl,
-            })),
-          };
-          storage.boosts.add(identity?.npub, stored);
-          bumpBoosts();
-          successfulIdx.push(i);
-          hostShareSats += showLegSats;
-        } else if (trackSats === 0) {
-          // No track payment to skip — full amount lands on host
-          hostShareSats += sats;
+        if (trackSats > 0) {
+          const results = await sendBoost({
+            value: split.value!,
+            totalSats: trackSats,
+            boostagram: trackBoostagram,
+            rail,
+          });
+          trackOk = results.some((r) => r.ok);
+          if (trackOk) {
+            const stored: StoredBoost = {
+              uuid: trackBoostagram.uuid!,
+              ts: Date.now(),
+              podcastTitle: podcast.title,
+              podcastId: podcast.id,
+              podcastGuid: podcast.podcastGuid,
+              podcastImage: split.image ?? episode.image ?? podcast.image,
+              episodeTitle: episode.title,
+              episodeGuid: episode.guid,
+              sats: trackSats,
+              message: msg || undefined,
+              senderName: name || undefined,
+              legs: results.map((r) => ({
+                recipient: r.recipient.address,
+                recipientName: r.recipient.name,
+                sats: r.sats,
+                ok: r.ok,
+                error: r.error,
+                boostboxUrl: r.boostboxUrl,
+              })),
+            };
+            storage.boosts.add(identity?.npub, stored);
+            bumpBoosts();
+            successfulIdx.push(i);
+          }
         }
-        if (cancelled.current) return;
-        setProgress((prev) => [...prev, { index: i, ok }]);
       } catch (e) {
         if (cancelled.current) return;
         setProgress((prev) => [
           ...prev,
           { index: i, ok: false, error: getErrorMessage(e, 'boost failed') },
         ]);
+        continue;
       }
-    }
 
-    // Spec: the host show gets (100 − remotePercentage)% of each track. We
-    // accumulated the floored remainder across all tracks; send it now as
-    // one show-level leg so the host's recipients aren't shorted entirely.
-    // Falls back to podcast.value when the episode itself has no value block.
-    const hostValue = episode.value ?? podcast.value;
-    if (hostShareSats > 0 && hostValue?.recipients?.length && !cancelled.current) {
-      const hostBoostagram: Boostagram = {
-        app_name: 'BoostMeBitch',
-        app_version: '0.1.0',
-        podcast: podcast.title,
-        feedID: podcast.id,
-        url: podcast.url,
-        episode: episode.title,
-        itemID: episode.id,
-        episode_guid: episode.guid,
-        ts: 0,
-        value_msat_total: hostShareSats * 1000,
-        message: msg || undefined,
-        sender_name: name || undefined,
-        sender_id: identity?.pubkey,
-        action: 'boost',
-        uuid: crypto.randomUUID(),
-      };
-      try {
-        const hostResults = await sendBoost({
-          value: hostValue,
-          totalSats: hostShareSats,
-          boostagram: hostBoostagram,
-          rail,
-        });
-        if (hostResults.some((r) => r.ok)) {
-          const stored: StoredBoost = {
-            uuid: hostBoostagram.uuid!,
-            ts: Date.now(),
-            podcastTitle: podcast.title,
-            podcastId: podcast.id,
-            podcastGuid: podcast.podcastGuid,
-            podcastImage: episode.image ?? podcast.image,
-            episodeTitle: episode.title,
-            episodeGuid: episode.guid,
-            sats: hostShareSats,
-            message: msg || undefined,
-            senderName: name || undefined,
-            legs: hostResults.map((r) => ({
-              recipient: r.recipient.address,
-              recipientName: r.recipient.name,
-              sats: r.sats,
-              ok: r.ok,
-              error: r.error,
-              boostboxUrl: r.boostboxUrl,
-            })),
-          };
-          storage.boosts.add(identity?.npub, stored);
-          bumpBoosts();
+      // Per-track host leg. Each one carries the same remote_* tags as its
+      // sibling track leg so the host can see which track triggered it in
+      // their boostagram log. Skip if remotePct === 100 (no host share),
+      // hostValue is missing, or showLegSats rounded to 0.
+      if (showLegSats > 0 && hostValue?.recipients?.length && !cancelled.current) {
+        const hostBoostagram: Boostagram = {
+          app_name: 'BoostMeBitch',
+          app_version: '0.1.0',
+          podcast: podcast.title,
+          feedID: podcast.id,
+          url: podcast.url,
+          episode: episode.title,
+          itemID: episode.id,
+          episode_guid: episode.guid,
+          remote_feed_guid: split.remoteItem?.feedGuid,
+          remote_item_guid: split.remoteItem?.itemGuid,
+          ts: 0,
+          value_msat_total: showLegSats * 1000,
+          message: msg || undefined,
+          sender_name: name || undefined,
+          sender_id: identity?.pubkey,
+          action: 'boost',
+          uuid: crypto.randomUUID(),
+        };
+        try {
+          const hostResults = await sendBoost({
+            value: hostValue,
+            totalSats: showLegSats,
+            boostagram: hostBoostagram,
+            rail,
+          });
+          if (hostResults.some((r) => r.ok)) {
+            const stored: StoredBoost = {
+              uuid: hostBoostagram.uuid!,
+              ts: Date.now(),
+              podcastTitle: podcast.title,
+              podcastId: podcast.id,
+              podcastGuid: podcast.podcastGuid,
+              podcastImage: episode.image ?? podcast.image,
+              episodeTitle: episode.title,
+              episodeGuid: episode.guid,
+              sats: showLegSats,
+              message: msg || undefined,
+              senderName: name || undefined,
+              legs: hostResults.map((r) => ({
+                recipient: r.recipient.address,
+                recipientName: r.recipient.name,
+                sats: r.sats,
+                ok: r.ok,
+                error: r.error,
+                boostboxUrl: r.boostboxUrl,
+              })),
+            };
+            storage.boosts.add(identity?.npub, stored);
+            bumpBoosts();
+          }
+        } catch {
+          // Host leg failure is non-fatal — the track leg may have already paid.
         }
-      } catch {
-        // Host leg failure is non-fatal — track legs already paid out.
       }
+
+      if (cancelled.current) return;
+      setProgress((prev) => [...prev, { index: i, ok: trackOk }]);
     }
 
     setRunning(false);

--- a/components/boost-all-modal.tsx
+++ b/components/boost-all-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useMemo, useState } from 'react';
-import type { Episode, Podcast, Boostagram, ValueTimeSplit } from '@/lib/types';
+import type { Episode, Podcast, Boostagram, ValueTimeSplit, StoredBoost } from '@/lib/types';
 import { useApp } from '@/lib/store';
 import { sendBoost, pickRail, type Rail } from '@/lib/v4v/boost';
 import { hasNwc, subscribeNwc } from '@/lib/v4v/nwc';
@@ -28,6 +28,7 @@ interface TrackProgress {
 
 export function BoostAllModal({ podcast, episode, onClose }: Props) {
   const identity = useApp((s) => s.identity);
+  const bumpBoosts = useApp((s) => s.bumpBoosts);
   const [sats, setSats] = useState(100);
   const [msg, setMsg] = useState('');
   const [name, setName] = useState('');
@@ -97,15 +98,21 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
 
     for (let i = 0; i < splits.length; i++) {
       const split = splits[i];
+      // Boostagram shape for valueTimeSplits: HOST episode in primary fields
+      // (the album/playlist the listener is playing), TRACK in remote_*. The
+      // recipient artist sees `podcast`/`episode` describing the listener's
+      // context and `remote_*` identifying which track triggered the boost.
       const boostagram: Boostagram = {
         app_name: 'BoostMeBitch',
         app_version: '0.1.0',
-        podcast: split.title ?? episode.title,
-        feedID: split.feedId ?? episode.feedId,
-        episode: split.title,
-        episode_guid: split.episodeGuid,
+        podcast: podcast.title,
+        feedID: podcast.id,
+        url: podcast.url,
+        episode: episode.title,
+        itemID: episode.id,
+        episode_guid: episode.guid,
         remote_feed_guid: split.remoteItem?.feedGuid,
-        remote_item_guid: split.episodeGuid,
+        remote_item_guid: split.remoteItem?.itemGuid,
         ts: 0,
         value_msat_total: sats * 1000,
         message: msg || undefined,
@@ -122,6 +129,31 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
           rail,
         });
         const ok = results.some((r) => r.ok);
+        if (ok) {
+          const stored: StoredBoost = {
+            uuid: boostagram.uuid!,
+            ts: Date.now(),
+            podcastTitle: podcast.title,
+            podcastId: podcast.id,
+            podcastGuid: podcast.podcastGuid,
+            podcastImage: split.image ?? episode.image ?? podcast.image,
+            episodeTitle: episode.title,
+            episodeGuid: episode.guid,
+            sats,
+            message: msg || undefined,
+            senderName: name || undefined,
+            legs: results.map((r) => ({
+              recipient: r.recipient.address,
+              recipientName: r.recipient.name,
+              sats: r.sats,
+              ok: r.ok,
+              error: r.error,
+              boostboxUrl: r.boostboxUrl,
+            })),
+          };
+          storage.boosts.add(identity?.npub, stored);
+          bumpBoosts();
+        }
         setProgress((prev) => [...prev, { index: i, ok }]);
       } catch (e) {
         setProgress((prev) => [

--- a/components/boost-all-modal.tsx
+++ b/components/boost-all-modal.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import confetti from 'canvas-confetti';
 import type { Episode, Podcast, Boostagram, ValueTimeSplit, StoredBoost } from '@/lib/types';
 import { useApp } from '@/lib/store';
 import { sendBoost, pickRail, type Rail } from '@/lib/v4v/boost';
@@ -15,6 +16,16 @@ import { MessageInput } from './boost-modal/message-input';
 import { SenderName } from './boost-modal/sender-name';
 import { PublishStatus, type PublishState } from './boost-modal/publish-status';
 import { PodcastCover } from './podcast-cover';
+
+// Brand-coloured celebration: bolt yellow, nostr magenta, bone. Mirrors
+// boost-modal/index.tsx so the single-boost and boost-all flows feel the same.
+function fireConfetti() {
+  const colors = ['#fae500', '#ff2d92', '#f5f1e8'];
+  confetti({ particleCount: 80, spread: 70, startVelocity: 55, origin: { y: 0.7 }, colors });
+  setTimeout(() => {
+    confetti({ particleCount: 50, spread: 100, startVelocity: 45, origin: { y: 0.7 }, colors });
+  }, 200);
+}
 
 interface Props {
   podcast: Podcast;
@@ -199,6 +210,8 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
     setRunning(false);
     setDone(true);
 
+    if (successfulIdx.length > 0) fireConfetti();
+
     // Single summary note covering all successful tracks. Gated on the
     // share-on-Nostr toggle and at least one paid leg — matches BoostModal's
     // "don't pollute the network with failed-only boosts" rule.
@@ -208,9 +221,7 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
     const totalSats = successfulIdx.length * sats;
     const trackList = successfulIdx
       .map((i) => splits[i].title)
-      .filter((t): t is string => !!t)
-      .slice(0, 8);
-    const moreCount = successfulIdx.length - trackList.length;
+      .filter((t): t is string => !!t);
 
     const summaryBoostagram: Boostagram = {
       app_name: 'BoostMeBitch',
@@ -238,7 +249,6 @@ export function BoostAllModal({ podcast, episode, onClose }: Props) {
     if (trackList.length) {
       lines.push('');
       for (const t of trackList) lines.push(`• ${t}`);
-      if (moreCount > 0) lines.push(`…and ${moreCount} more`);
     }
     const contentOverride = lines.join('\n');
 

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -4,6 +4,7 @@ import type { Episode, Podcast, FavoritePodcast, ValueBlock } from '@/lib/types'
 import { useApp } from '@/lib/store';
 import { resolvePublishRelays, schedulePublishFavorites } from '@/lib/nostr';
 import { BoostModal } from './boost-modal';
+import { BoostAllModal } from './boost-all-modal';
 import { BoltIcon } from './icons';
 import { PodcastCover } from './podcast-cover';
 import { PodcastNostrFeed } from './podcast-nostr-feed';
@@ -258,6 +259,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
   const [loading, setLoading] = useState(false);
   const [showBoostOpen, setShowBoostOpen] = useState(false);
   const [liveBoostFor, setLiveBoostFor] = useState<Episode | null>(null);
+  const [boostAllFor, setBoostAllFor] = useState<Episode | null>(null);
   const [valueOpen, setValueOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const play = useApp((s) => s.play);
@@ -409,6 +411,19 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   <BoltIcon />
                 </button>
               ) : null}
+              {e.valueTimeSplits?.length ? (
+                <button
+                  type="button"
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    setBoostAllFor(e);
+                  }}
+                  className="btn-ghost self-center flex-shrink-0 text-bolt text-xs px-2 py-1"
+                  title="Boost all tracks in this episode"
+                >
+                  ⚡ {e.valueTimeSplits.length}
+                </button>
+              ) : null}
             </li>
             </Fragment>
           );
@@ -435,6 +450,14 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
         <BoostModal
           podcast={data.podcast}
           onClose={() => setShowBoostOpen(false)}
+        />
+      )}
+
+      {boostAllFor && data.podcast && (
+        <BoostAllModal
+          episode={boostAllFor}
+          podcast={data.podcast}
+          onClose={() => setBoostAllFor(null)}
         />
       )}
     </div>

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -418,10 +418,10 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                     ev.stopPropagation();
                     setBoostAllFor(e);
                   }}
-                  className="btn-ghost self-center flex-shrink-0 text-bolt text-xs px-2 py-1"
-                  title="Boost all tracks in this episode"
+                  className="btn-ghost self-center flex-shrink-0 text-bolt text-[11px] px-2 py-1 whitespace-nowrap uppercase tracking-wider"
+                  title={`Boost all ${e.valueTimeSplits.length} tracks in this episode`}
                 >
-                  ⚡ {e.valueTimeSplits.length}
+                  ⚡ Boost {e.valueTimeSplits.length} tracks
                 </button>
               ) : null}
             </li>

--- a/lib/musicl-resolver.ts
+++ b/lib/musicl-resolver.ts
@@ -1,0 +1,192 @@
+// Server-side fallback resolver for valueTimeSplits whose remote items
+// PI doesn't index. Walks the Podcasting 2.0 publisher → album feed chain:
+//
+//   1. Host RSS valueTimeSplit ──▶ publisher feedGuid + itemGuid
+//   2. Publisher feed (medium=publisher) ──▶ <podcast:remoteItem feedUrl="…"> entries
+//   3. Album feed ──▶ contains the actual <item> with the matching <guid> and
+//      a <podcast:value> block
+//
+// PI's /episodes/byguid only finds items it has crawled. Many small-artist
+// album feeds aren't in PI, but the publisher feed is — so we fetch the
+// publisher RSS to get album feed URLs, then fetch the album RSS to extract
+// the value block. Falls back to the album's channel-level value block if
+// the item itself has none.
+
+import type { ValueBlock, ValueRecipient } from './types';
+
+const FETCH_TIMEOUT_MS = 5000;
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CachedFeed {
+  xml: string;
+  expires: number;
+}
+const feedCache = new Map<string, CachedFeed>();
+
+async function fetchFeedXml(url: string): Promise<string | null> {
+  const cached = feedCache.get(url);
+  if (cached && cached.expires > Date.now()) return cached.xml;
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      headers: { 'User-Agent': 'boostmebitch musicl-resolver' },
+    });
+    if (!res.ok) return null;
+    const xml = await res.text();
+    feedCache.set(url, { xml, expires: Date.now() + CACHE_TTL_MS });
+    return xml;
+  } catch {
+    return null;
+  }
+}
+
+function parseValueRecipients(valueXml: string): ValueRecipient[] {
+  const recRe = /<podcast:valueRecipient\b[^/>]*\/?>/g;
+  const recipients: ValueRecipient[] = [];
+  for (const m of valueXml.matchAll(recRe)) {
+    const block = m[0];
+    const name = /name="([^"]*)"/.exec(block)?.[1];
+    const typeStr = /type="([^"]*)"/.exec(block)?.[1];
+    const address = /address="([^"]*)"/.exec(block)?.[1];
+    const split = Number(/split="([^"]*)"/.exec(block)?.[1] ?? '0');
+    const fee = /fee="true"/i.test(block);
+    const customKey = /customKey="([^"]*)"/.exec(block)?.[1];
+    const customValue = /customValue="([^"]*)"/.exec(block)?.[1];
+    if (!address || (typeStr !== 'node' && typeStr !== 'lnaddress')) continue;
+    recipients.push({
+      name,
+      type: typeStr,
+      address,
+      split: Number.isFinite(split) ? split : 0,
+      fee,
+      customKey,
+      customValue,
+    });
+  }
+  return recipients;
+}
+
+function extractValueBlock(scopeXml: string): ValueBlock | null {
+  const valMatch = /<podcast:value\b[^>]*>[\s\S]*?<\/podcast:value>/.exec(scopeXml);
+  if (!valMatch) return null;
+  const recipients = parseValueRecipients(valMatch[0]);
+  if (recipients.length === 0) return null;
+  const method = /method="([^"]+)"/.exec(valMatch[0])?.[1] || 'keysend';
+  return { type: 'lightning', method, recipients };
+}
+
+interface FoundItem {
+  itemXml: string;
+  title?: string;
+  image?: string;
+}
+
+function findItemByGuid(xml: string, itemGuid: string): FoundItem | null {
+  // Split on <item> tags. Skip the channel header (slice(1)).
+  const itemChunks = xml.split(/<item\b[^>]*>/).slice(1);
+  for (const chunk of itemChunks) {
+    const closeIdx = chunk.indexOf('</item>');
+    if (closeIdx === -1) continue;
+    const itemXml = chunk.slice(0, closeIdx);
+    // Match guid as the actual <guid> tag content, not a substring elsewhere
+    const guidMatch = /<guid\b[^>]*>([^<]+)<\/guid>/.exec(itemXml);
+    if (!guidMatch || guidMatch[1].trim() !== itemGuid) continue;
+    const titleMatch = /<title>([\s\S]*?)<\/title>/.exec(itemXml);
+    const imageMatch =
+      /<itunes:image[^>]+href="([^"]+)"/.exec(itemXml)
+      ?? /<image>[\s\S]*?<url>([^<]+)<\/url>/.exec(itemXml);
+    return {
+      itemXml,
+      title: titleMatch?.[1].trim(),
+      image: imageMatch?.[1],
+    };
+  }
+  return null;
+}
+
+function channelScope(xml: string): string {
+  // Everything before the first <item> tag — the channel header where
+  // channel-level <podcast:value> lives.
+  const firstItem = xml.search(/<item\b[^>]*>/);
+  return firstItem === -1 ? xml : xml.slice(0, firstItem);
+}
+
+function isPublisherFeed(xml: string): boolean {
+  return /<podcast:medium>\s*publisher\s*<\/podcast:medium>/i.test(xml);
+}
+
+function publisherRemoteItemUrls(xml: string): string[] {
+  const urls: string[] = [];
+  const remoteItemRe = /<podcast:remoteItem\b[^>]*>/g;
+  for (const m of xml.matchAll(remoteItemRe)) {
+    const url = /feedUrl="([^"]+)"/.exec(m[0])?.[1];
+    if (url) urls.push(url);
+  }
+  return urls;
+}
+
+export interface ResolvedRemoteItem {
+  value: ValueBlock;
+  title?: string;
+  image?: string;
+}
+
+/**
+ * Try to resolve a (feedGuid, itemGuid) remoteItem reference by fetching
+ * the source RSS feed directly. Handles two cases:
+ *   - feedGuid points at the album feed → find the item, return its value
+ *   - feedGuid points at a publisher feed → walk publisher.remoteItems[],
+ *     fetch each album feed in parallel, return the first match
+ *
+ * Returns null if the item can't be located. Uses an in-memory cache so
+ * repeated calls within a 5min window don't re-fetch the same RSS.
+ *
+ * `feedUrl` is supplied separately because PI's /podcasts/byguid is the
+ * cheapest way to translate feedGuid → feedUrl, and the caller (lib/pi.ts)
+ * already has PI client wiring.
+ */
+export async function resolveRemoteItemFromRss(
+  feedUrl: string,
+  itemGuid: string,
+): Promise<ResolvedRemoteItem | null> {
+  const xml = await fetchFeedXml(feedUrl);
+  if (!xml) return null;
+
+  // Direct hit: the feedGuid pointed at an album feed that contains the item
+  const direct = findItemByGuid(xml, itemGuid);
+  if (direct) {
+    const itemValue = extractValueBlock(direct.itemXml);
+    if (itemValue) {
+      return { value: itemValue, title: direct.title, image: direct.image };
+    }
+    const channelValue = extractValueBlock(channelScope(xml));
+    if (channelValue) {
+      return { value: channelValue, title: direct.title, image: direct.image };
+    }
+  }
+
+  // Publisher chain: walk remoteItems[] for an album feed that contains the item
+  if (!isPublisherFeed(xml)) return null;
+  const albumUrls = publisherRemoteItemUrls(xml);
+  if (albumUrls.length === 0) return null;
+
+  const candidates = await Promise.all(
+    albumUrls.map(async (albumUrl): Promise<ResolvedRemoteItem | null> => {
+      const albumXml = await fetchFeedXml(albumUrl);
+      if (!albumXml) return null;
+      const found = findItemByGuid(albumXml, itemGuid);
+      if (!found) return null;
+      const itemValue = extractValueBlock(found.itemXml);
+      if (itemValue) {
+        return { value: itemValue, title: found.title, image: found.image };
+      }
+      const channelValue = extractValueBlock(channelScope(albumXml));
+      if (channelValue) {
+        return { value: channelValue, title: found.title, image: found.image };
+      }
+      return null;
+    }),
+  );
+
+  return candidates.find((c): c is ResolvedRemoteItem => c !== null) ?? null;
+}

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -298,8 +298,11 @@ export async function getEpisodeByGuid(
   feedGuid: string,
   itemGuid: string,
 ): Promise<Episode | null> {
+  // PI's /episodes/byguid wants `podcastguid` (lowercase, no camelCase) for
+  // the feed identifier. The variable here is named feedGuid because that's
+  // what the RSS spec calls it on <podcast:remoteItem feedGuid="...">.
   const data = await pi<any>(
-    `/episodes/byguid?guid=${encodeURIComponent(itemGuid)}&feedGuid=${encodeURIComponent(feedGuid)}`,
+    `/episodes/byguid?guid=${encodeURIComponent(itemGuid)}&podcastguid=${encodeURIComponent(feedGuid)}`,
   );
   return data.episode ? buildEpisode(data.episode) : null;
 }

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -91,19 +91,25 @@ export async function getPodcastByGuid(guid: string): Promise<Podcast | null> {
   return buildPodcast(Array.isArray(f) ? f[0] : f);
 }
 
+// PI exposes valueTimeSplits as a flat top-level `timesplits` array on each
+// episode (each entry has feedGuid/itemGuid/medium directly, NOT under a
+// nested remoteItem). We keep the consumer-facing ValueTimeSplit shape with
+// remoteItem nested because that mirrors the Podcasting 2.0 RSS structure
+// and matches how downstream code (boost-all-modal, /api/value-splits) reads
+// the data.
 function parseRawValueTimeSplits(raw: any): ValueTimeSplit[] {
   if (!Array.isArray(raw) || !raw.length) return [];
   return raw
-    .filter((s: any) => s?.remoteItem?.feedGuid)
+    .filter((s: any) => s?.feedGuid)
     .map((s: any) => ({
       startTime: Number(s.startTime) || 0,
       duration: Number(s.duration) || 0,
       remoteStartTime: s.remoteStartTime != null ? Number(s.remoteStartTime) : undefined,
       remotePercentage: s.remotePercentage != null ? Number(s.remotePercentage) : undefined,
       remoteItem: {
-        feedGuid: s.remoteItem.feedGuid,
-        itemGuid: s.remoteItem.itemGuid,
-        medium: s.remoteItem.medium,
+        feedGuid: s.feedGuid,
+        itemGuid: s.itemGuid,
+        medium: s.medium || undefined,
       },
     }));
 }
@@ -124,7 +130,7 @@ function buildEpisode(e: any): Episode {
     feedImage: e.feedImage,
     podcastGuid: e.podcastGuid,
     value: normalizeValue(e.value),
-    valueTimeSplits: parseRawValueTimeSplits(e.value?.valueTimeSplits),
+    valueTimeSplits: parseRawValueTimeSplits(e.timesplits),
   };
 }
 

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -298,28 +298,42 @@ export async function getEpisodeByGuid(
   return data.episode ? buildEpisode(data.episode) : null;
 }
 
+async function resolveOneSplit(split: ValueTimeSplit): Promise<ValueTimeSplit> {
+  if (!split.remoteItem?.feedGuid || !split.remoteItem.itemGuid) return split;
+  const ep = await getEpisodeByGuid(split.remoteItem.feedGuid, split.remoteItem.itemGuid);
+  return {
+    ...split,
+    value: ep?.value ?? null,
+    title: ep?.title,
+    image: ep?.image,
+    feedId: ep?.feedId,
+    episodeGuid: ep?.guid,
+  };
+}
+
 export async function resolveValueTimeSplits(
   splits: ValueTimeSplit[],
 ): Promise<ValueTimeSplit[]> {
+  if (splits.length === 0) return [];
+
+  // Probe with the first resolvable split. If it throws, PI is likely down —
+  // return everything unresolved rather than firing N more failing calls.
+  // Per-call failures inside the fan-out are still caught individually.
+  const probeIdx = splits.findIndex(
+    (s) => s.remoteItem?.feedGuid && s.remoteItem.itemGuid,
+  );
+  if (probeIdx === -1) return splits;
+  let probeResolved: ValueTimeSplit;
+  try {
+    probeResolved = await resolveOneSplit(splits[probeIdx]);
+  } catch {
+    return splits;
+  }
+
   return Promise.all(
-    splits.map(async (split): Promise<ValueTimeSplit> => {
-      if (!split.remoteItem?.feedGuid || !split.remoteItem.itemGuid) return split;
-      try {
-        const ep = await getEpisodeByGuid(
-          split.remoteItem.feedGuid,
-          split.remoteItem.itemGuid,
-        );
-        return {
-          ...split,
-          value: ep?.value ?? null,
-          title: ep?.title,
-          image: ep?.image,
-          feedId: ep?.feedId,
-          episodeGuid: ep?.guid,
-        };
-      } catch {
-        return split;
-      }
+    splits.map(async (s, i): Promise<ValueTimeSplit> => {
+      if (i === probeIdx) return probeResolved;
+      try { return await resolveOneSplit(s); } catch { return s; }
     }),
   );
 }

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -1,6 +1,7 @@
 // Server-side Podcast Index client. Never import from a client component.
 import crypto from 'node:crypto';
 import type { Podcast, Episode, ValueBlock, ValueRecipient, ValueTimeSplit } from './types';
+import { resolveRemoteItemFromRss } from './musicl-resolver';
 
 const BASE = 'https://api.podcastindex.org/api/1.0';
 
@@ -310,14 +311,39 @@ export async function getEpisodeByGuid(
 async function resolveOneSplit(split: ValueTimeSplit): Promise<ValueTimeSplit> {
   if (!split.remoteItem?.feedGuid || !split.remoteItem.itemGuid) return split;
   const ep = await getEpisodeByGuid(split.remoteItem.feedGuid, split.remoteItem.itemGuid);
-  return {
-    ...split,
-    value: ep?.value ?? null,
-    title: ep?.title,
-    image: ep?.image,
-    feedId: ep?.feedId,
-    episodeGuid: ep?.guid,
-  };
+  if (ep?.value) {
+    return {
+      ...split,
+      value: ep.value,
+      title: ep.title,
+      image: ep.image,
+      feedId: ep.feedId,
+      episodeGuid: ep.guid,
+    };
+  }
+  // PI didn't have the item — try the RSS chain. Two cases this rescues:
+  //   1. PI knows the feed but hasn't crawled the specific item
+  //   2. The host's valueTimeSplit feedGuid points at a publisher feed
+  //      (medium=publisher) whose <podcast:remoteItem> entries name the
+  //      actual album feed URLs we need to fetch.
+  // Both need the feed URL, which we get cheaply via /podcasts/byguid.
+  try {
+    const feedRes = await pi<any>(
+      `/podcasts/byguid?guid=${encodeURIComponent(split.remoteItem.feedGuid)}`,
+    );
+    const feedUrl: string | undefined = feedRes.feed?.url;
+    if (!feedUrl) return split;
+    const rss = await resolveRemoteItemFromRss(feedUrl, split.remoteItem.itemGuid);
+    if (!rss) return split;
+    return {
+      ...split,
+      value: rss.value,
+      title: rss.title,
+      image: rss.image,
+    };
+  } catch {
+    return split;
+  }
 }
 
 export async function resolveValueTimeSplits(

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -1,6 +1,6 @@
 // Server-side Podcast Index client. Never import from a client component.
 import crypto from 'node:crypto';
-import type { Podcast, Episode, ValueBlock, ValueRecipient } from './types';
+import type { Podcast, Episode, ValueBlock, ValueRecipient, ValueTimeSplit } from './types';
 
 const BASE = 'https://api.podcastindex.org/api/1.0';
 
@@ -91,6 +91,23 @@ export async function getPodcastByGuid(guid: string): Promise<Podcast | null> {
   return buildPodcast(Array.isArray(f) ? f[0] : f);
 }
 
+function parseRawValueTimeSplits(raw: any): ValueTimeSplit[] {
+  if (!Array.isArray(raw) || !raw.length) return [];
+  return raw
+    .filter((s: any) => s?.remoteItem?.feedGuid)
+    .map((s: any) => ({
+      startTime: Number(s.startTime) || 0,
+      duration: Number(s.duration) || 0,
+      remoteStartTime: s.remoteStartTime != null ? Number(s.remoteStartTime) : undefined,
+      remotePercentage: s.remotePercentage != null ? Number(s.remotePercentage) : undefined,
+      remoteItem: {
+        feedGuid: s.remoteItem.feedGuid,
+        itemGuid: s.remoteItem.itemGuid,
+        medium: s.remoteItem.medium,
+      },
+    }));
+}
+
 function buildEpisode(e: any): Episode {
   return {
     id: e.id,
@@ -107,6 +124,7 @@ function buildEpisode(e: any): Episode {
     feedImage: e.feedImage,
     podcastGuid: e.podcastGuid,
     value: normalizeValue(e.value),
+    valueTimeSplits: parseRawValueTimeSplits(e.value?.valueTimeSplits),
   };
 }
 
@@ -268,6 +286,42 @@ function extractText(xml: string, tag: string): string | undefined {
     .replace(/&apos;/g, "'")
     .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCharCode(parseInt(h, 16)))
     .replace(/&#(\d+);/g, (_, d) => String.fromCharCode(Number(d)));
+}
+
+export async function getEpisodeByGuid(
+  feedGuid: string,
+  itemGuid: string,
+): Promise<Episode | null> {
+  const data = await pi<any>(
+    `/episodes/byguid?guid=${encodeURIComponent(itemGuid)}&feedGuid=${encodeURIComponent(feedGuid)}`,
+  );
+  return data.episode ? buildEpisode(data.episode) : null;
+}
+
+export async function resolveValueTimeSplits(
+  splits: ValueTimeSplit[],
+): Promise<ValueTimeSplit[]> {
+  return Promise.all(
+    splits.map(async (split): Promise<ValueTimeSplit> => {
+      if (!split.remoteItem?.feedGuid || !split.remoteItem.itemGuid) return split;
+      try {
+        const ep = await getEpisodeByGuid(
+          split.remoteItem.feedGuid,
+          split.remoteItem.itemGuid,
+        );
+        return {
+          ...split,
+          value: ep?.value ?? null,
+          title: ep?.title,
+          image: ep?.image,
+          feedId: ep?.feedId,
+          episodeGuid: ep?.guid,
+        };
+      } catch {
+        return split;
+      }
+    }),
+  );
 }
 
 // 32-bit FNV-1a; just need a stable non-colliding key for React + the store.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -17,6 +17,26 @@ export interface ValueBlock {
   recipients: ValueRecipient[];
 }
 
+export interface ValueTimeSplitRemoteItem {
+  feedGuid: string;
+  itemGuid?: string;
+  medium?: string;
+}
+
+export interface ValueTimeSplit {
+  startTime: number;
+  duration: number;
+  remoteStartTime?: number;
+  remotePercentage?: number;   // % of sats going to remoteItem (rest goes to episode value block)
+  remoteItem?: ValueTimeSplitRemoteItem;
+  // Populated by /api/value-splits after resolution:
+  value?: ValueBlock | null;
+  title?: string;
+  image?: string;
+  feedId?: number;
+  episodeGuid?: string;
+}
+
 export interface Podcast {
   id: number;
   podcastGuid?: string;   // namespace UUID for NIP-73 podcast:guid:
@@ -49,6 +69,7 @@ export interface Episode {
   feedImage?: string;
   podcastGuid?: string;
   value?: ValueBlock | null;
+  valueTimeSplits?: ValueTimeSplit[];
   /** Podcast 2.0 <podcast:liveItem> status. Set on items returned by PI's
    *  /episodes/live endpoint. We filter out 'ended' upstream, so only
    *  'live' and 'pending' should ever reach the client. */


### PR DESCRIPTION
Sends a fixed per-track amount to every value block in a music episode.
Parses valueTimeSplits from the Podcast Index API, resolves remoteItem
references to get each track's lightning recipients, and sends one
boost per track via a new dedicated modal.

New files:
- app/api/value-splits/route.ts — resolves remoteItem value blocks, 1h cache
- components/boost-all-modal.tsx — track list, per-track amount, sequential send

Modified:
- lib/types.ts — ValueTimeSplit, ValueTimeSplitRemoteItem types; Episode.valueTimeSplits
- lib/pi.ts — parseRawValueTimeSplits, getEpisodeByGuid, resolveValueTimeSplits
- components/lists.tsx — ⚡ N button on episodes with valueTimeSplits

https://claude.ai/code/session_015qNDBB6JqmmfYkkaqbgD5C