### PR TITLE
feat: expandable episode rows with per-episode boost

### DIFF
--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -18,6 +18,31 @@ function fmtDuration(t: number) {
   return `${m}:${s}`;
 }
 
+// Render-as-text only — strips tags + decodes a few common entities. Episode
+// descriptions are typically plain text or lightly-tagged HTML; full sanitization
+// isn't needed because we never feed this into dangerouslySetInnerHTML.
+function stripHtml(s: string): string {
+  return s
+    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+    .replace(/<\/(p|div|li)\s*>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+interface ChapterEntry {
+  startTime: number;
+  title?: string;
+  image?: string;
+  url?: string;
+}
+
 function fmtLiveTime(unixSec: number) {
   const d = new Date(unixSec * 1000);
   const today = new Date();
@@ -252,15 +277,156 @@ function ValueBlockDetails({ value }: { value: ValueBlock }) {
   );
 }
 
+function ChaptersList({
+  episodeId,
+  url,
+  cache,
+  setCache,
+  loadingFor,
+  setLoadingFor,
+}: {
+  episodeId: number;
+  url: string;
+  cache: Map<number, ChapterEntry[]>;
+  setCache: React.Dispatch<React.SetStateAction<Map<number, ChapterEntry[]>>>;
+  loadingFor: number | null;
+  setLoadingFor: React.Dispatch<React.SetStateAction<number | null>>;
+}) {
+  const cached = cache.get(episodeId);
+
+  useEffect(() => {
+    if (cache.has(episodeId)) return;
+    if (loadingFor === episodeId) return;
+    setLoadingFor(episodeId);
+    fetch(url)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        const list: ChapterEntry[] = Array.isArray(data?.chapters)
+          ? data.chapters.map((c: any) => ({
+              startTime: Number(c.startTime) || 0,
+              title: typeof c.title === 'string' ? c.title : undefined,
+              image: c.img || c.image,
+              url: c.url,
+            }))
+          : [];
+        setCache((prev) => new Map(prev).set(episodeId, list));
+      })
+      .catch(() => setCache((prev) => new Map(prev).set(episodeId, [])))
+      .finally(() => setLoadingFor((cur) => (cur === episodeId ? null : cur)));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [episodeId, url]);
+
+  if (loadingFor === episodeId && !cached) {
+    return <p className="text-xs text-muted">Loading chapters…</p>;
+  }
+  if (!cached?.length) return null;
+
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-widest text-muted mb-1.5">
+        Chapters ({cached.length})
+      </p>
+      <ul className="space-y-1 text-xs max-h-60 overflow-y-auto pr-2">
+        {cached.map((c, i) => (
+          <li key={i} className="flex gap-3 text-bone/80">
+            <span className="text-muted tabular-nums w-12 flex-shrink-0">
+              {fmtDuration(c.startTime)}
+            </span>
+            <span className="truncate">{c.title ?? `Chapter ${i + 1}`}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ExpandedEpisodePanel({
+  episode,
+  podcast,
+  onBoost,
+  chaptersCache,
+  setChaptersCache,
+  chaptersLoading,
+  setChaptersLoading,
+}: {
+  episode: Episode;
+  podcast: Podcast;
+  onBoost: () => void;
+  chaptersCache: Map<number, ChapterEntry[]>;
+  setChaptersCache: React.Dispatch<React.SetStateAction<Map<number, ChapterEntry[]>>>;
+  chaptersLoading: number | null;
+  setChaptersLoading: React.Dispatch<React.SetStateAction<number | null>>;
+}) {
+  const value = episode.value ?? podcast.value;
+  const hasValue = !!value?.recipients?.length;
+  const description = episode.description ? stripHtml(episode.description) : '';
+
+  return (
+    <div
+      className="border-t border-bone/10 px-4 py-4 space-y-4 bg-bone/[0.02]"
+      onClick={(ev) => ev.stopPropagation()}
+    >
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted">
+        {episode.datePublished && (
+          <span>{new Date(episode.datePublished * 1000).toLocaleDateString()}</span>
+        )}
+        {episode.duration ? <span>· {fmtDuration(episode.duration)}</span> : null}
+        {episode.episode ? <span>· Episode {episode.episode}</span> : null}
+        {episode.season ? <span>· Season {episode.season}</span> : null}
+      </div>
+
+      {description && (
+        <div className="text-sm text-bone/80 leading-relaxed whitespace-pre-wrap max-h-72 overflow-y-auto pr-2">
+          {description}
+        </div>
+      )}
+
+      {value && (
+        <div>
+          <p className="text-[11px] uppercase tracking-widest text-muted mb-1.5">Value split</p>
+          <ValueBlockDetails value={value} />
+        </div>
+      )}
+
+      {episode.chaptersUrl && (
+        <ChaptersList
+          episodeId={episode.id}
+          url={episode.chaptersUrl}
+          cache={chaptersCache}
+          setCache={setChaptersCache}
+          loadingFor={chaptersLoading}
+          setLoadingFor={setChaptersLoading}
+        />
+      )}
+
+      {hasValue && (
+        <button
+          type="button"
+          onClick={(ev) => {
+            ev.stopPropagation();
+            onBoost();
+          }}
+          className="btn-bolt"
+        >
+          <BoltIcon /> BOOST EPISODE
+        </button>
+      )}
+    </div>
+  );
+}
+
 export function EpisodeList({ feedId }: { feedId: number | null }) {
   const [data, setData] = useState<{ podcast: Podcast | null; episodes: Episode[] }>({
     podcast: null, episodes: [],
   });
   const [loading, setLoading] = useState(false);
   const [showBoostOpen, setShowBoostOpen] = useState(false);
-  const [liveBoostFor, setLiveBoostFor] = useState<Episode | null>(null);
+  const [boostFor, setBoostFor] = useState<Episode | null>(null);
   const [boostAllFor, setBoostAllFor] = useState<Episode | null>(null);
   const [valueOpen, setValueOpen] = useState(false);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [chaptersByEpisode, setChaptersByEpisode] = useState<Map<number, ChapterEntry[]>>(new Map());
+  const [chaptersLoading, setChaptersLoading] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const play = useApp((s) => s.play);
   const current = useApp((s) => s.current);
@@ -352,15 +518,24 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                 </li>
               )}
             <li
-              className={`flex gap-3 py-3 group transition ${
-                playing ? 'bg-bolt/10' : e.liveStatus !== 'pending' ? 'hover:bg-bone/5' : ''
-              } ${e.liveStatus !== 'pending' ? 'cursor-pointer' : ''}`}
-              onClick={() => {
-                if (e.liveStatus === 'pending') return;
-                if (data.podcast) play(e, data.podcast);
-              }}
+              className={`group transition ${
+                playing ? 'bg-bolt/10' : expandedId === e.id ? 'bg-bone/[0.03]' : 'hover:bg-bone/5'
+              } cursor-pointer`}
+              onClick={() => setExpandedId((cur) => (cur === e.id ? null : e.id))}
             >
-              <div className="relative w-12 h-12 flex-shrink-0">
+              <div className="flex gap-3 py-3 pr-3">
+              <button
+                type="button"
+                onClick={(ev) => {
+                  ev.stopPropagation();
+                  if (e.liveStatus === 'pending') return;
+                  if (data.podcast) play(e, data.podcast);
+                }}
+                disabled={e.liveStatus === 'pending'}
+                className="relative w-12 h-12 flex-shrink-0 disabled:cursor-not-allowed"
+                title={e.liveStatus === 'pending' ? 'Not started yet' : playing ? 'Now playing' : 'Play'}
+                aria-label={playing ? 'Now playing' : 'Play'}
+              >
                 <PodcastCover
                   image={e.image}
                   artwork={e.feedImage || data.podcast?.artwork}
@@ -379,7 +554,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                     {playing ? '❚❚' : '▶'}
                   </div>
                 )}
-              </div>
+              </button>
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-2">
                   {e.liveStatus && <LiveBadge status={e.liveStatus} />}
@@ -403,7 +578,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   type="button"
                   onClick={(ev) => {
                     ev.stopPropagation();
-                    setLiveBoostFor(e);
+                    setBoostFor(e);
                   }}
                   className="btn-bolt self-center flex-shrink-0"
                   title="Boost this live item"
@@ -424,6 +599,32 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   ⚡ Boost {e.valueTimeSplits.length} tracks
                 </button>
               ) : null}
+              {!e.liveStatus && (e.value ?? data.podcast?.value)?.recipients?.length ? (
+                <button
+                  type="button"
+                  onClick={(ev) => {
+                    ev.stopPropagation();
+                    setBoostFor(e);
+                  }}
+                  className="btn-bolt self-center flex-shrink-0"
+                  title="Boost this episode"
+                  aria-label="Boost this episode"
+                >
+                  <BoltIcon />
+                </button>
+              ) : null}
+              </div>
+              {expandedId === e.id && data.podcast && (
+                <ExpandedEpisodePanel
+                  episode={e}
+                  podcast={data.podcast}
+                  onBoost={() => setBoostFor(e)}
+                  chaptersCache={chaptersByEpisode}
+                  setChaptersCache={setChaptersByEpisode}
+                  chaptersLoading={chaptersLoading}
+                  setChaptersLoading={setChaptersLoading}
+                />
+              )}
             </li>
             </Fragment>
           );
@@ -437,12 +638,12 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
         />
       )}
 
-      {liveBoostFor && data.podcast && (
+      {boostFor && data.podcast && (
         <BoostModal
-          episode={liveBoostFor}
+          episode={boostFor}
           podcast={data.podcast}
           positionSec={0}
-          onClose={() => setLiveBoostFor(null)}
+          onClose={() => setBoostFor(null)}
         />
       )}
 

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -130,6 +130,9 @@ function buildEpisode(e: any): Episode {
     feedTitle: e.feedTitle,
     feedImage: e.feedImage,
     podcastGuid: e.podcastGuid,
+    episode: typeof e.episode === 'number' ? e.episode : null,
+    season: typeof e.season === 'number' && e.season > 0 ? e.season : null,
+    chaptersUrl: typeof e.chaptersUrl === 'string' && e.chaptersUrl.length > 0 ? e.chaptersUrl : undefined,
     value: normalizeValue(e.value),
     valueTimeSplits: parseRawValueTimeSplits(e.timesplits),
   };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -68,6 +68,9 @@ export interface Episode {
   feedTitle?: string;
   feedImage?: string;
   podcastGuid?: string;
+  episode?: number | null;     // <itunes:episode> if present
+  season?: number | null;      // <itunes:season> if present
+  chaptersUrl?: string;        // PI exposes Podcasting 2.0 chapters JSON URL
   value?: ValueBlock | null;
   valueTimeSplits?: ValueTimeSplit[];
   /** Podcast 2.0 <podcast:liveItem> status. Set on items returned by PI's


### PR DESCRIPTION
## Summary
- Click an episode row to expand it inline (only one open at a time)
- Expanded panel shows date/duration/episode #, description, value-split, chapters, and a ⚡ BOOST EPISODE button
- Cover artwork is the play trigger (▶ on hover, ❚❚ when playing)
- New ⚡ button on the far right of every non-live episode for quick per-episode boost
- Surfaces Episode.episode / Episode.season / Episode.chaptersUrl from PI through buildEpisode (data was already there, just not propagated)

## Test plan
- [ ] Open a podcast detail view; click any episode row → expands inline
- [ ] Click the cover artwork → starts playback without expanding
- [ ] ⚡ BOOST on far-right of a row → opens BoostModal for that episode
- [ ] ⚡ BOOST EPISODE inside expanded panel → same modal
- [ ] Existing ⚡ live-boost and ⚡ BOOST N TRACKS buttons still work and don't trigger expansion
- [ ] Chapters list renders for episodes with chaptersUrl, absent otherwise
- [ ] Description renders as text (no raw HTML tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)