### PR TITLE
Fix text overlap in episode rows on mobile

### DIFF
--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -572,6 +572,19 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   {e.duration && <span>· {fmtDuration(e.duration)}</span>}
                   {e.value && <span className="text-bolt">· ⚡ V4V</span>}
                 </div>
+                {e.valueTimeSplits?.length ? (
+                  <button
+                    type="button"
+                    onClick={(ev) => {
+                      ev.stopPropagation();
+                      setBoostAllFor(e);
+                    }}
+                    className="btn-ghost mt-1.5 text-bolt text-[11px] px-2 py-1 whitespace-nowrap uppercase tracking-wider"
+                    title={`Boost all ${e.valueTimeSplits.length} tracks in this episode`}
+                  >
+                    ⚡ Boost {e.valueTimeSplits.length} tracks
+                  </button>
+                ) : null}
               </div>
               {e.liveStatus && (e.value ?? data.podcast?.value)?.recipients?.length ? (
                 <button
@@ -584,19 +597,6 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   title="Boost this live item"
                 >
                   <BoltIcon />
-                </button>
-              ) : null}
-              {e.valueTimeSplits?.length ? (
-                <button
-                  type="button"
-                  onClick={(ev) => {
-                    ev.stopPropagation();
-                    setBoostAllFor(e);
-                  }}
-                  className="btn-ghost self-center flex-shrink-0 text-bolt text-[11px] px-2 py-1 whitespace-nowrap uppercase tracking-wider"
-                  title={`Boost all ${e.valueTimeSplits.length} tracks in this episode`}
-                >
-                  ⚡ Boost {e.valueTimeSplits.length} tracks
                 </button>
               ) : null}
               {!e.liveStatus && (e.value ?? data.podcast?.value)?.recipients?.length ? (


### PR DESCRIPTION
## Summary

- The "⚡ BOOST N TRACKS" button was a flex sibling of the title/metadata div, competing for horizontal space in the episode row
- On narrow mobile screens this caused the date and duration text to overlap with the button text
- Moved the button inside the text column so it renders below the date/duration line instead

**Before:** `[▶] [Title | date · duration] [⚡ BOOST N TRACKS] [⚡]`

**After:**
```
[▶] [Title (full width)         ] [⚡]
    [date · duration · V4V      ]
    [⚡ BOOST N TRACKS          ]
```

## Test plan

- [ ] Open Lightning Thrashes (or any music podcast with valueTimeSplits)
- [ ] Confirm episode rows show title, date/duration, and "⚡ BOOST N TRACKS" button stacked cleanly with no overlap on mobile
- [ ] Confirm the ⚡ bolt button still appears on the right and opens the boost modal
- [ ] Confirm tapping "⚡ BOOST N TRACKS" still opens the Boost All modal

https://claude.ai/code/session_01KHaZ3y9mY8UA7vVo6caUxh

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHaZ3y9mY8UA7vVo6caUxh)_