### PR TITLE
feat: add podcast:socialInteract tag support (Nostr only)

### DIFF
--- a/components/episode-social-thread.tsx
+++ b/components/episode-social-thread.tsx
@@ -1,0 +1,72 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { fetchSocialInteractThread, type DiscoveredNote } from '@/lib/nostr';
+import { useApp } from '@/lib/store';
+import type { SocialInteract } from '@/lib/types';
+import { NoteCard } from './nostr-note-card';
+
+function countNotes(notes: DiscoveredNote[]): number {
+  return notes.reduce((sum, n) => sum + 1 + countNotes(n.replies), 0);
+}
+
+export function EpisodeSocialThread({ entries }: { entries: SocialInteract[] }) {
+  const [notes, setNotes] = useState<DiscoveredNote[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const mutedPubkeys = useApp((s) => s.mutedPubkeys);
+
+  const primary = entries[0];
+  const njumpUrl = primary.uri.startsWith('nostr:')
+    ? `https://njump.me/${primary.uri.slice(6)}`
+    : null;
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    fetchSocialInteractThread(primary.uri)
+      .then((n) => { if (!cancelled) setNotes(n); })
+      .catch(() => { if (!cancelled) setNotes([]); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [primary.uri]);
+
+  const visibleNotes = useMemo(
+    () => (notes ? notes.filter((n) => !mutedPubkeys.has(n.pubkey)) : notes),
+    [notes, mutedPubkeys],
+  );
+
+  const total = visibleNotes ? countNotes(visibleNotes) : 0;
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-2">
+        <p className="text-[11px] uppercase tracking-widest text-muted flex-1">
+          Nostr comments
+          {!loading && total > 0 && (
+            <span className="ml-1 text-nostr">({total})</span>
+          )}
+        </p>
+        {njumpUrl && (
+          <a
+            href={njumpUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[11px] text-muted hover:text-nostr"
+          >
+            view on nostr →
+          </a>
+        )}
+      </div>
+      {loading && <p className="text-xs text-muted">loading thread…</p>}
+      {!loading && visibleNotes !== null && total === 0 && (
+        <p className="text-xs text-muted">no replies yet</p>
+      )}
+      {visibleNotes && visibleNotes.length > 0 && (
+        <div className="space-y-3 max-h-96 overflow-y-auto pr-1">
+          {visibleNotes.map((n) => (
+            <NoteCard key={n.id} note={n} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/episode-social-thread.tsx
+++ b/components/episode-social-thread.tsx
@@ -9,7 +9,13 @@ function countNotes(notes: DiscoveredNote[]): number {
   return notes.reduce((sum, n) => sum + 1 + countNotes(n.replies), 0);
 }
 
-export function EpisodeSocialThread({ entries }: { entries: SocialInteract[] }) {
+export function EpisodeSocialThread({
+  entries,
+  label = 'Nostr comments',
+}: {
+  entries: SocialInteract[];
+  label?: string;
+}) {
   const [notes, setNotes] = useState<DiscoveredNote[] | null>(null);
   const [loading, setLoading] = useState(false);
   const mutedPubkeys = useApp((s) => s.mutedPubkeys);
@@ -40,7 +46,7 @@ export function EpisodeSocialThread({ entries }: { entries: SocialInteract[] }) 
     <div>
       <div className="flex items-center gap-3 mb-2">
         <p className="text-[11px] uppercase tracking-widest text-muted flex-1">
-          Nostr comments
+          {label}
           {!loading && total > 0 && (
             <span className="ml-1 text-nostr">({total})</span>
           )}

--- a/components/fullscreen-player.tsx
+++ b/components/fullscreen-player.tsx
@@ -2,6 +2,7 @@
 import { RefObject, useEffect, useState } from 'react';
 import { useApp } from '@/lib/store';
 import { BoltIcon } from './icons';
+import { EpisodeSocialThread } from './episode-social-thread';
 import { PodcastCover } from './podcast-cover';
 
 function fmt(t: number) {
@@ -264,6 +265,12 @@ export function FullscreenPlayer({
                 />
               </div>
             )}
+
+            {episode.socialInteract?.length ? (
+              <div className="border-t border-bone/10 pt-5">
+                <EpisodeSocialThread entries={episode.socialInteract} />
+              </div>
+            ) : null}
           </div>
         </div>
       </div>

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -9,7 +9,6 @@ import { BoltIcon, ShareIcon } from './icons';
 import { PodcastCover } from './podcast-cover';
 import { PodcastNostrFeed } from './podcast-nostr-feed';
 import { DeferredOnScroll } from './deferred-on-scroll';
-import { EpisodeSocialThread } from './episode-social-thread';
 
 function fmtDuration(t: number) {
   if (!isFinite(t) || t <= 0) return '';
@@ -440,10 +439,6 @@ function ExpandedEpisodePanel({
         />
       )}
 
-      {episode.socialInteract?.length ? (
-        <EpisodeSocialThread entries={episode.socialInteract} />
-      ) : null}
-
       {hasValue && (
         <button
           type="button"
@@ -692,6 +687,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
           <PodcastNostrFeed
             podcastGuid={data.podcast.podcastGuid}
             podcastTitle={data.podcast.title}
+            pinnedSocialInteract={data.episodes.find((e) => e.socialInteract?.length)?.socialInteract}
           />
         </DeferredOnScroll>
       )}

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -9,6 +9,7 @@ import { BoltIcon, ShareIcon } from './icons';
 import { PodcastCover } from './podcast-cover';
 import { PodcastNostrFeed } from './podcast-nostr-feed';
 import { DeferredOnScroll } from './deferred-on-scroll';
+import { EpisodeSocialThread } from './episode-social-thread';
 
 function fmtDuration(t: number) {
   if (!isFinite(t) || t <= 0) return '';
@@ -439,6 +440,10 @@ function ExpandedEpisodePanel({
         />
       )}
 
+      {episode.socialInteract?.length ? (
+        <EpisodeSocialThread entries={episode.socialInteract} />
+      ) : null}
+
       {hasValue && (
         <button
           type="button"
@@ -612,6 +617,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   )}
                   {e.duration && <span>· {fmtDuration(e.duration)}</span>}
                   {e.value && <span className="text-bolt">· ⚡ V4V</span>}
+                  {e.socialInteract?.length ? <span className="text-nostr">· 💬</span> : null}
                 </div>
                 {e.valueTimeSplits?.length ? (
                   <button

--- a/components/podcast-nostr-feed.tsx
+++ b/components/podcast-nostr-feed.tsx
@@ -7,8 +7,10 @@ import {
   type DiscoveredNote,
 } from '@/lib/nostr';
 import { useApp } from '@/lib/store';
+import type { SocialInteract } from '@/lib/types';
 import { FeedSection } from './feed-section';
 import { NoteCard } from './nostr-note-card';
+import { EpisodeSocialThread } from './episode-social-thread';
 
 /**
  * Per-podcast Nostr stream — same card UI as <GlobalNostrFeed>, but the relay
@@ -19,9 +21,11 @@ import { NoteCard } from './nostr-note-card';
 export function PodcastNostrFeed({
   podcastGuid,
   podcastTitle,
+  pinnedSocialInteract,
 }: {
   podcastGuid: string;
   podcastTitle?: string;
+  pinnedSocialInteract?: SocialInteract[];
 }) {
   const { notes, loading, err, refresh } = useNostrFeed({
     cacheKey: `podcast:${podcastGuid}`,
@@ -44,6 +48,13 @@ export function PodcastNostrFeed({
           <span className="text-nostr">#</span> Boosts &amp; chatter on Nostr
           {podcastTitle ? <span className="text-muted text-sm"> · {podcastTitle}</span> : null}
         </h3>
+      }
+      description={
+        pinnedSocialInteract?.length ? (
+          <div className="mb-4 pb-4 border-b border-bone/10">
+            <EpisodeSocialThread entries={pinnedSocialInteract} label="📌 Episode thread" />
+          </div>
+        ) : undefined
       }
       notes={visibleNotes}
       loading={loading}

--- a/lib/nostr/discover.ts
+++ b/lib/nostr/discover.ts
@@ -1,5 +1,5 @@
 import { nip19, type Event } from 'nostr-tools';
-import { withPool, withExtraRelays, FEED_QUERY_MAX_WAIT_MS } from './pool';
+import { withPool, withExtraRelays, FEED_QUERY_MAX_WAIT_MS, QUERY_MAX_WAIT_MS } from './pool';
 import { DEFAULT_RELAYS, PROFILE_RELAYS } from './relays';
 import { storage } from '../storage';
 import { parseProfileContent, type ProfileMetadata } from './auth';
@@ -234,6 +234,55 @@ export async function fetchPodcastNotes(
       return [];
     }
     return await assembleNotes(pool, relays, events);
+  });
+}
+
+/**
+ * Fetch the Nostr thread referenced by a `<podcast:socialInteract>` URI.
+ * Decodes a `nostr:note1…` or `nostr:nevent1…` URI, fetches the root event
+ * (using any relay hints embedded in the nevent), then assembles the full
+ * reply tree exactly like the per-podcast feed does.
+ *
+ * Returns `[]` on any decode/fetch failure so callers can render a graceful
+ * empty state instead of throwing.
+ */
+export async function fetchSocialInteractThread(
+  nostrUri: string,
+  opts: FetchOpts = {},
+): Promise<DiscoveredNote[]> {
+  const bech32 = nostrUri.startsWith('nostr:') ? nostrUri.slice(6) : nostrUri;
+  let eventId: string;
+  let hintRelays: string[] = [];
+  try {
+    const decoded = nip19.decode(bech32);
+    if (decoded.type === 'note') {
+      eventId = decoded.data;
+    } else if (decoded.type === 'nevent') {
+      eventId = decoded.data.id;
+      hintRelays = decoded.data.relays ?? [];
+    } else {
+      return [];
+    }
+  } catch {
+    return [];
+  }
+
+  const baseRelays = opts.relays ?? DEFAULT_RELAYS;
+  const allRelays = Array.from(new Set([...baseRelays, ...hintRelays.slice(0, 4)]));
+
+  return withPool(allRelays, async (pool) => {
+    let rootEvents: Event[] = [];
+    try {
+      rootEvents = await pool.querySync(
+        allRelays,
+        { ids: [eventId] },
+        { maxWait: QUERY_MAX_WAIT_MS },
+      );
+    } catch {
+      return [];
+    }
+    if (!rootEvents.length) return [];
+    return assembleNotes(pool, allRelays, rootEvents);
   });
 }
 

--- a/lib/nostr/index.ts
+++ b/lib/nostr/index.ts
@@ -35,6 +35,7 @@ export {
 export {
   fetchAllPodcastNotes,
   fetchPodcastNotes,
+  fetchSocialInteractThread,
   type DiscoveredNote,
 } from './discover';
 

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -1,6 +1,6 @@
 // Server-side Podcast Index client. Never import from a client component.
 import crypto from 'node:crypto';
-import type { Podcast, Episode, ValueBlock, ValueRecipient, ValueTimeSplit } from './types';
+import type { Podcast, Episode, ValueBlock, ValueRecipient, ValueTimeSplit, SocialInteract } from './types';
 import { resolveRemoteItemFromRss } from './musicl-resolver';
 
 const BASE = 'https://api.podcastindex.org/api/1.0';
@@ -115,6 +115,56 @@ function parseRawValueTimeSplits(raw: any): ValueTimeSplit[] {
     }));
 }
 
+// Normalise a raw URI field from <podcast:socialInteract> to a `nostr:` URI.
+// Some publishers use https://njump.me/<bech32> instead of the spec-compliant
+// `nostr:<bech32>` form — extract the bech32 from either.
+function extractNostrUri(raw: string): string | null {
+  if (raw.startsWith('nostr:')) return raw;
+  const m = raw.match(/\/(n(?:event|ote|addr|profile|pub)1[023456789acdefghjklmnpqrstuvwxyz]+)/);
+  return m ? `nostr:${m[1]}` : null;
+}
+
+function parseNostrSocialInteracts(raw: any): SocialInteract[] | undefined {
+  if (!Array.isArray(raw) || !raw.length) return undefined;
+  const results: SocialInteract[] = [];
+  for (const s of raw) {
+    if (typeof s?.uri !== 'string') continue;
+    if (s.protocol !== 'nostr') continue;
+    const uri = extractNostrUri(s.uri);
+    if (!uri) continue;
+    results.push({
+      uri,
+      accountId: typeof s.accountId === 'string' && s.accountId ? s.accountId : undefined,
+      priority: typeof s.priority === 'number' ? s.priority : undefined,
+    });
+  }
+  if (!results.length) return undefined;
+  return results.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+}
+
+function parseSocialInteractsFromRss(xml: string): SocialInteract[] | undefined {
+  const results: SocialInteract[] = [];
+  const re = /<podcast:socialInteract\b([^>]*?)\/?>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(xml))) {
+    const attrs = m[1];
+    if (readAttr(attrs, 'protocol') !== 'nostr') continue;
+    const rawUri = readAttr(attrs, 'uri');
+    if (!rawUri) continue;
+    const uri = extractNostrUri(rawUri);
+    if (!uri) continue;
+    const accountId = readAttr(attrs, 'accountId');
+    const priorityStr = readAttr(attrs, 'priority');
+    results.push({
+      uri,
+      accountId: accountId || undefined,
+      priority: priorityStr !== undefined ? Number(priorityStr) : undefined,
+    });
+  }
+  if (!results.length) return undefined;
+  return results.sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+}
+
 function buildEpisode(e: any): Episode {
   return {
     id: e.id,
@@ -135,6 +185,7 @@ function buildEpisode(e: any): Episode {
     chaptersUrl: typeof e.chaptersUrl === 'string' && e.chaptersUrl.length > 0 ? e.chaptersUrl : undefined,
     value: normalizeValue(e.value),
     valueTimeSplits: parseRawValueTimeSplits(e.timesplits),
+    socialInteract: parseNostrSocialInteracts(e.socialInteract),
   };
 }
 
@@ -202,6 +253,7 @@ export async function getLiveItemsFromRss(
     liveStatus: r.status,
     liveStartTime: r.startTime,
     value: r.value,
+    socialInteract: r.socialInteract,
   }));
 }
 
@@ -215,6 +267,7 @@ interface RawLiveItem {
   enclosureType?: string;
   image?: string;
   value?: ValueBlock | null;
+  socialInteract?: SocialInteract[];
 }
 
 function parseRssLiveItems(xml: string): RawLiveItem[] {
@@ -241,6 +294,7 @@ function parseRssLiveItems(xml: string): RawLiveItem[] {
       enclosureType: enc ? readAttr(enc[1], 'type') : undefined,
       image: itunesImg ? readAttr(itunesImg[1], 'href') : undefined,
       value: parseValueBlock(inner),
+      socialInteract: parseSocialInteractsFromRss(inner),
     });
   }
   return out;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -54,6 +54,12 @@ export interface Podcast {
   value?: ValueBlock | null;
 }
 
+export interface SocialInteract {
+  uri: string;          // nostr: URI (note1, nevent1)
+  accountId?: string;   // npub of the account that posted it
+  priority?: number;
+}
+
 export interface Episode {
   id: number;
   guid?: string;          // episode GUID for NIP-73 podcast:item:guid:
@@ -73,6 +79,7 @@ export interface Episode {
   chaptersUrl?: string;        // PI exposes Podcasting 2.0 chapters JSON URL
   value?: ValueBlock | null;
   valueTimeSplits?: ValueTimeSplit[];
+  socialInteract?: SocialInteract[];
   /** Podcast 2.0 <podcast:liveItem> status. Set on items returned by PI's
    *  /episodes/live endpoint. We filter out 'ended' upstream, so only
    *  'live' and 'pending' should ever reach the client. */


### PR DESCRIPTION
Parses <podcast:socialInteract protocol="nostr"> tags from Podcast Index
episode responses and from RSS live items. Fetches the referenced Nostr
thread (note1/nevent1) inline using relay hints from the nevent URI.
Displays the thread with NoteCards in the expanded episode panel and
fullscreen player; shows a "💬" indicator on episode rows that have one.

Handles both spec-compliant `nostr:<bech32>` URIs and non-standard
`https://njump.me/<bech32>` variants publishers sometimes emit.

https://claude.ai/code/session_01YQfGxTQD5HwkMJaHsELnMP