### PR TITLE
Swap Spark rail from Breez to Spark Labs SDK

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,9 @@
 PODCAST_INDEX_KEY=
 PODCAST_INDEX_SECRET=
 
-# Breez Spark SDK — get a key at https://breez.technology/sdk/
-# Required for the Spark payment rail. Public-flagged because the SDK
-# initializes in the browser (self-custodial wallet, key gates SDK
-# usage, not user wallets).
-NEXT_PUBLIC_BREEZ_API_KEY=
+# Spark rail uses @buildonspark/spark-sdk — no API key required (the SDK
+# talks directly to Spark's signing operators). Self-custodial; seed lives
+# NIP-44-encrypted on the user's Nostr relays.
 
 # Optional: app identity for Podcast Index User-Agent
 APP_NAME=boostmebitch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,13 @@ The README at the repo root is the architecture spec; treat overlap with this fi
 
 ```bash
 npm install
-cp .env.example .env.local       # PI key + secret + Breez key
+cp .env.example .env.local       # PI key + secret (Spark rail needs no key)
 npm run dev / build / start / lint
 ```
 
 **No test runner, no typecheck script, no formatter.** `next build` is the de facto typecheck (strict mode on). Path alias: `@/*` → repo root.
 
-`.env.local`: `PODCAST_INDEX_KEY`/`SECRET` (server-only), `NEXT_PUBLIC_BREEZ_API_KEY` (browser; the Spark SDK is self-custodial so the key gates SDK usage, not user funds), `APP_NAME` (optional).
+`.env.local`: `PODCAST_INDEX_KEY`/`SECRET` (server-only), `APP_NAME` (optional). The Spark rail (`@buildonspark/spark-sdk`) needs **no** API key — it talks straight to Spark's signing operators.
 
 ## Server vs client boundary (don't cross it)
 
@@ -137,25 +137,28 @@ Both come from `components/wallet-balance.tsx`. `useWalletBalance(railOverride?)
 
 All three balance helpers swallow errors and return null so a missing capability (NWC connection without `get_balance` permission, WebLN provider without `getBalance`) just hides the chip rather than throwing.
 
-**Last-known balance cache.** `useWalletBalance` writes the live `{ rail, balance }` to `storage.walletBalance` (per-npub) on every successful fetch, and reads it back on mount as a fallback. Without it, a returning user sees a blank chip for 5-10 s while Breez Spark cold-restores (relay query for the kind:30078 backup → NIP-44 decrypt → WASM load → `connect()` → initial sync). With it, the chip paints the cached number instantly and only swaps to the live value once the SDK is ready. Cleared on explicit Spark/NWC disconnect (`<SparkWallet>` and `<NwcWallet>` call `storage.walletBalance.clear(npub)`). The cached balance is only paired with a matching live rail — we never show a stale Spark balance under an NWC label.
+**Last-known balance cache.** `useWalletBalance` writes the live `{ rail, balance }` to `storage.walletBalance` (per-npub) on every successful fetch, and reads it back on mount as a fallback. Without it, a returning user sees a blank chip for 5-10 s while the Spark wallet cold-restores (relay query for the kind:30078 backup → NIP-44 decrypt → SDK load → `SparkWallet.initialize()` → initial sync). With it, the chip paints the cached number instantly and only swaps to the live value once the SDK is ready. Cleared on explicit Spark/NWC disconnect (`<SparkWallet>` and `<NwcWallet>` call `storage.walletBalance.clear(npub)`). The cached balance is only paired with a matching live rail — we never show a stale Spark balance under an NWC label.
 
-## Spark rail (Breez SDK)
+## Spark rail (Spark Labs SDK)
 
-`lib/v4v/spark.ts` wraps `@breeztech/breez-sdk-spark`. WASM only lands in the bundle on first wallet open (dynamic import inside `sparkInitFromMnemonic`).
+`lib/v4v/spark.ts` wraps `@buildonspark/spark-sdk` (the SDK ships an `eventemitter3`-based `SparkWallet`). The heavy SDK only lands in the bundle on first wallet open (dynamic import inside `sparkInitFromMnemonic`). No API key — the SDK talks directly to Spark's signing operators.
 
 Load-bearing rules:
 
 1. **BOLT11 only.** Spark cannot keysend. `lib/v4v/boost.ts` rejects every `node`-type recipient on the Spark rail per-leg with a clear error. lnaddress works because `payOne` fetches a BOLT11 from the LNURL-pay callback first.
-2. **Network is `mainnet` or `regtest` — no public testnet exists.** Use `network: 'regtest'` against a local node for development; the type union enforces this.
-3. **`storageDir` is keyed on `(ownerPubkey[:8], sha256(mnemonic)[:8])`.** Two wallets for the same npub get different SDK directories — `walletStorageDir()` does the hashing. Keying on pubkey alone collides on disconnect+recreate; the SDK either rejects re-init or corrupts state.
-4. **Two-step send.** `sparkPayInvoice` runs `sdk.prepareSendPayment({ paymentRequest })` then `sdk.sendPayment({ prepareResponse })`. Preimage from `payment.preimage` or `payment.details.htlcDetails.preimage`.
-5. **Events drive the balance, not polling.** `subscribeSparkEvents()` wraps the SDK's `addEventListener`. `paymentSucceeded`/`claimedDeposits`/`newDeposits`/`synced` trigger `sparkGetInfo()` in `<ReadyPanel>`; the first three also auto-dismiss any outstanding deposit invoice.
+2. **Account number = the SDK's per-network default (1 on mainnet, 0 on regtest).** `sparkInitFromMnemonic` sets `accountNumber: network === 'regtest' ? 0 : 1`. Spark's mainnet default is **1**, and Primal + BlitzWallet both use the default — so mirroring it makes the same seed derive the **same account and balance** as those wallets. ⚠️ Hardcoding `0` on mainnet derives a *different, empty* account (this was the first-cut bug — symptom was a connected wallet stuck at 0 sats). There is **no auto-migration** from the old Breez wallets (Breez derived its own keys); users must paste/restore a seed.
+3. **Network is `MAINNET` or `REGTEST` — no public testnet exists.** Our `network?: 'mainnet' | 'regtest'` arg maps to the SDK's `options.network` (`'REGTEST'` for dev against a local node, else `'MAINNET'`).
+4. **Init returns `{ wallet }`.** `const { wallet } = await SparkWallet.initialize({ mnemonicOrSeed, accountNumber: 0, options: { network } })`. No `storageDir`/`walletStorageDir` concept — that was Breez-only (the SDK keeps no local WASM storage dir we manage).
+5. **Send is one-shot.** `sparkPayInvoice` calls `sdk.payLightningInvoice({ invoice, maxFeeSats: 100 })`. The preimage is **not** returned synchronously, so we return `''` (`BoostResult.preimage` is optional and unread by the UI).
+6. **Receive.** `sparkReceiveInvoice` calls `sdk.createLightningInvoice({ amountSats, memo })` → BOLT11 at `result.invoice.encodedInvoice`. The SDK exposes no settle fee here, so `feeSats` is always 0 (ReadyPanel hides the fee line when 0).
+7. **Balance.** `sparkGetInfo` reads `sdk.getBalance()` → `satsBalance.available` (bigint, `Number()`-cast), falling back to the deprecated `balance` field.
+8. **Events drive the balance, not polling.** `subscribeSparkEvents()` registers `eventemitter3` `.on`/`.off` handlers and maps SDK events into the existing `SparkSdkEvent` union: `'transfer:claimed'` → `paymentSucceeded`, `'deposit:confirmed'` → `claimedDeposits` (both clear the open deposit invoice in `<ReadyPanel>`), `'balance:update'`/`'stream:connected'` → `synced` (plain refresh). The `newDeposits`/`optimization`/`lightningAddressChanged` union arms are no longer emitted but kept so consumers don't change.
 
-Mnemonic is published encrypt-to-self as kind:30078 (`lib/nostr/wallet-backup.ts`) — anyone with the user's nsec can decrypt; backup is convenience, not the only copy. The seed-display step is the user's chance to write it down. Re-create flow checks for an existing backup and confirms before overwrite (kind:30078 is NIP-33 replaceable — newer wins, prior is gone forever).
+**Onboarding (3 paths in `components/spark-wallet.tsx`).** Paste an existing seed (the Primal-balance-sharing path), **Create new** (mints via `sparkGenerateMnemonic`, SDK-independent `@scure/bip39`), or **Restore from Nostr**. All publish the seed encrypt-to-self as kind:30078 (`lib/nostr/wallet-backup.ts`) so silent auto-restore works next load; paste/create confirm before overwriting a *different* existing backup (kind:30078 is NIP-33 replaceable — newer wins, prior is gone forever).
 
 **Restore-side relay union.** `fetchEncryptedMnemonic` queries `resolvePublishRelays(identity) ∪ DEFAULT_RELAYS` (deduped, capped at 20) with the longer 8s `FEED_QUERY_MAX_WAIT_MS`. Otherwise a fresh Android Amber sign-in (where NIP-65 hasn't hydrated yet) falls back to defaults and misses backups on the user's outbox relays. `publishEncryptedMnemonic` stays on `resolvePublishRelays(identity)`.
 
-**Post-restore balance race.** `<ReadyPanel>` attaches the SDK event listener BEFORE the first `getInfo()` call, then re-polls at 2s/5s/12s. Otherwise Breez Spark's initial sync after `connect()` can complete between our `connect` resolving and the listener attaching, leaving the panel stuck at a cached 0.
+**Post-restore balance race.** `<ReadyPanel>` attaches the SDK event listener BEFORE the first balance call, then re-polls at 2s/5s/12s. Otherwise the SDK's initial sync after `initialize()` can complete between init resolving and the listener attaching, leaving the panel stuck at a cached 0.
 
 ## Show-level boost
 
@@ -318,7 +321,7 @@ Keys (per-identity ones key on `<npub>` or `:guest`):
 | `bmb:boosts:*` | Local sent-boost log, capped 200 newest-first. Each entry holds intent + per-leg results + Nostr `noteId` patched in once `publishBoostNote` resolves. `boostsTick` wakes subscribers; `GlobalNostrFeed` mixes these in and dedupes against returned notes by `noteId`. |
 | `bmb:pi:dead` (sessionStorage) | Circuit-breaker sentinel; cleared on hard-refresh-into-new-tab. |
 
-External: the **Spark mnemonic** lives encrypted on Nostr as kind:30078. Breez SDK's wallet state (UTXOs, payment history) lives in IndexedDB at `bmb-spark-<pubkey:8>-<sha256(mnemonic):8>`.
+External: the **Spark mnemonic** lives encrypted on Nostr as kind:30078. The `@buildonspark/spark-sdk` `SparkWallet` keeps its own wallet state (leaves, transfer history) keyed off the seed + `accountNumber: 0`; we don't manage a storage dir for it.
 
 ## Styling tokens
 

--- a/components/nwc-wallet.tsx
+++ b/components/nwc-wallet.tsx
@@ -90,7 +90,7 @@ export function NwcWallet({ mode, onConnected, onDisconnected }: Props) {
   if (hasNwc()) return null;
   return (
     <div className="space-y-2">
-      <div className="text-[11px] text-muted">
+      <div className="text-xs text-bone/70 leading-relaxed">
         Paste a nostr+walletconnect:// URI from Alby Hub, getalby.com, or your own node.
       </div>
       <input

--- a/components/nwc-wallet.tsx
+++ b/components/nwc-wallet.tsx
@@ -91,7 +91,7 @@ export function NwcWallet({ mode, onConnected, onDisconnected }: Props) {
   return (
     <div className="space-y-2">
       <div className="text-xs text-bone/70 leading-relaxed">
-        Paste a nostr+walletconnect:// URI from Alby Hub, getalby.com, or your own node.
+        Paste a nostr+walletconnect:// URI from any NWC-compatible wallet.
       </div>
       <input
         className="input"

--- a/components/spark-wallet.tsx
+++ b/components/spark-wallet.tsx
@@ -33,6 +33,7 @@ export function SparkWallet({ mode, onConnected, onDisconnected }: Props) {
   const [internalMode, setInternalMode] = useState<InternalMode>('idle');
   const [draftMnemonic, setDraftMnemonic] = useState<string | null>(null);
   const [confirmed, setConfirmed] = useState(false);
+  const [pasteSeed, setPasteSeed] = useState('');
   const [err, setErr] = useState<string | null>(null);
 
   const owner = sparkOwner();
@@ -109,6 +110,43 @@ export function SparkWallet({ mode, onConnected, onDisconnected }: Props) {
     }
   }
 
+  // Paste an existing seed (e.g. the user's Primal wallet) to share its balance.
+  async function connectPasted() {
+    setErr(null);
+    if (!identity) { setErr('Sign in with Nostr first — backups need your pubkey.'); return; }
+    const trimmed = pasteSeed.trim().replace(/\s+/g, ' ');
+    const words = trimmed ? trimmed.split(' ') : [];
+    if (words.length !== 12 && words.length !== 24) {
+      setErr('Seed must be 12 or 24 words.');
+      return;
+    }
+    setInternalMode('busy');
+    try {
+      // kind:30078 is replaceable — only confirm an overwrite when a DIFFERENT
+      // wallet is already backed up. Re-pasting the same seed is harmless.
+      const existing = await fetchEncryptedMnemonic(identity).catch(() => null);
+      if (existing && existing.trim().replace(/\s+/g, ' ') !== trimmed) {
+        const ok = window.confirm(
+          'A different Spark wallet backup already exists on your relays.\n\n' +
+          'Connecting this seed will OVERWRITE that backup. The old wallet ' +
+          'will be unrecoverable unless you wrote its seed phrase down.\n\n' +
+          'Continue and overwrite?'
+        );
+        if (!ok) { setInternalMode('idle'); return; }
+      }
+      storage.sparkOptOut.clear();
+      await sparkInitFromMnemonic({ mnemonic: trimmed, ownerPubkey: identity.pubkey });
+      // Back up so silent auto-restore works on the next load. Non-fatal.
+      await publishEncryptedMnemonic(identity, trimmed).catch(() => {});
+      setPasteSeed('');
+      setInternalMode('idle');
+      onConnected?.();
+    } catch (e) {
+      setErr(getErrorMessage(e, 'failed to connect wallet'));
+      setInternalMode('idle');
+    }
+  }
+
   async function disconnect() {
     await sparkDisconnect();
     storage.sparkOptOut.set();
@@ -161,7 +199,28 @@ export function SparkWallet({ mode, onConnected, onDisconnected }: Props) {
       <div className="text-[11px] text-muted">
         Self-custodial wallet. Mnemonic is NIP-44 encrypted to your pubkey and stored on your write relays.
       </div>
-      <div className="flex gap-2 flex-wrap">
+      <div className="space-y-2">
+        <div className="text-[11px] text-muted">
+          Paste an existing 12- or 24-word seed (e.g. your Primal wallet) to share its balance.
+        </div>
+        <textarea
+          className="input w-full h-16 resize-none"
+          placeholder="word1 word2 word3 …"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          value={pasteSeed}
+          onChange={(e) => setPasteSeed(e.target.value)}
+        />
+        <button
+          onClick={connectPasted}
+          disabled={internalMode === 'busy' || !identity || !pasteSeed.trim()}
+          className="btn-bolt disabled:opacity-30"
+        >
+          {internalMode === 'busy' ? 'Connecting…' : 'Connect'}
+        </button>
+      </div>
+      <div className="flex gap-2 flex-wrap pt-1 border-t border-line">
         <button
           onClick={startCreate}
           disabled={internalMode === 'busy' || !identity}
@@ -178,7 +237,7 @@ export function SparkWallet({ mode, onConnected, onDisconnected }: Props) {
         </button>
       </div>
       {!identity && (
-        <div className="text-[11px] text-muted">Sign in with Nostr to create or restore.</div>
+        <div className="text-[11px] text-muted">Sign in with Nostr to connect, create, or restore.</div>
       )}
       {err && <div className="text-[11px] text-nostr/80">{err}</div>}
     </div>

--- a/components/spark-wallet.tsx
+++ b/components/spark-wallet.tsx
@@ -196,12 +196,12 @@ export function SparkWallet({ mode, onConnected, onDisconnected }: Props) {
 
   return (
     <div className="space-y-2">
-      <div className="text-[11px] text-muted">
+      <div className="text-xs text-bone/70 leading-relaxed">
         Self-custodial wallet. Mnemonic is NIP-44 encrypted to your pubkey and stored on your write relays.
       </div>
       <div className="space-y-2">
-        <div className="text-[11px] text-muted">
-          Paste an existing 12- or 24-word seed (e.g. your Primal wallet) to share its balance.
+        <div className="text-xs text-bone/70 leading-relaxed">
+          Paste an existing 12- or 24-word seed (e.g. Primal, Blitz, or any Spark wallet) to share its balance.
         </div>
         <textarea
           className="input w-full h-16 resize-none"

--- a/components/wallet-modal.tsx
+++ b/components/wallet-modal.tsx
@@ -203,7 +203,7 @@ export function WalletModal({ onClose }: Props) {
                   <span className="ml-2 text-[11px] text-bolt">(active)</span>
                 )}
               </div>
-              <div className="text-[11px] text-muted mt-0.5">{desc}</div>
+              <div className="text-xs text-bone/70 mt-0.5">{desc}</div>
             </button>
           ))}
         </div>

--- a/components/webln-wallet.tsx
+++ b/components/webln-wallet.tsx
@@ -49,7 +49,7 @@ export function WeblnWallet({ mode, onConnected, onDisconnected }: Props) {
   if (enabled) return null;
   return (
     <div className="space-y-2">
-      <div className="text-[11px] text-muted">WebLN extension detected.</div>
+      <div className="text-xs text-bone/70 leading-relaxed">WebLN extension detected.</div>
       <button onClick={enable} disabled={enabling} className="btn-ghost disabled:opacity-30">
         {enabling ? 'Enabling…' : 'Enable for this site'}
       </button>

--- a/docs/spark-sdk-swap.md
+++ b/docs/spark-sdk-swap.md
@@ -1,0 +1,311 @@
+# Spark SDK Swap: Breez → Spark Labs
+
+## Why
+
+boostmebitch currently uses `@breeztech/breez-sdk-spark`, which derives wallet keys at
+`m/8797555'/1'/…` (account 1 on mainnet). BlitzWallet, Primal, and every other Spark
+app use `@buildonspark/spark-sdk`, which defaults to `m/8797555'/0'/…` (account 0).
+Different account number → different wallet → same seed phrase produces different funds
+in each app.
+
+The goal: user sets up BlitzWallet on their phone, pastes that same seed phrase into
+boostmebitch, and both apps share the same Spark balance. boostmebitch will no longer
+generate wallets for users.
+
+---
+
+## What Changes
+
+### 1. `package.json`
+
+```diff
+- "@breeztech/breez-sdk-spark": "^0.13.6",
++ "@buildonspark/spark-sdk": "^0.8.0",
+```
+
+Run `npm install` after.
+
+### 2. `.env.example` (and `.env.local`)
+
+Remove the Breez API key — the Spark Labs SDK doesn't need one:
+
+```diff
+- NEXT_PUBLIC_BREEZ_API_KEY=your_breez_api_key_here
+```
+
+Also delete the `NEXT_PUBLIC_BREEZ_API_KEY` check inside `sparkInitFromMnemonic` in
+`lib/v4v/spark.ts`.
+
+### 3. `lib/v4v/spark.ts` — full rewrite
+
+The file stays `'use client'` and exports the same public surface so nothing else needs
+to change. Internals are completely different.
+
+**Import:**
+```ts
+import { SparkWallet, SparkWalletBrowser, SparkWalletEvent } from '@buildonspark/spark-sdk';
+```
+
+Use `SparkWalletBrowser` (not `SparkWallet`) — it wires the browser-compatible
+gRPC-web connection manager. The package's conditional exports resolve the right entry
+point automatically in Next.js client bundles.
+
+**Initialization:**
+```ts
+const { wallet: w } = await SparkWalletBrowser.initialize({
+  mnemonicOrSeed: args.mnemonic,
+  accountNumber: 0,               // must be 0 — matches BlitzWallet / Primal default
+  options: {
+    network: args.network === 'regtest' ? 'REGTEST' : 'MAINNET',
+  },
+});
+sdk = w;
+activePubkey = args.ownerPubkey;
+```
+
+`accountNumber: 0` is the critical line. Omitting it or passing `undefined` still
+defaults to 0 in the Spark Labs SDK, but be explicit so future readers don't wonder.
+
+**`walletStorageDir` — drop it.** The Spark Labs SDK manages its own IndexedDB storage
+keyed internally. No `storageDir` parameter exists on `initialize`.
+
+**`sparkGenerateMnemonic` — delete it.** Users bring their own seed from BlitzWallet.
+Nothing else in the codebase calls this function.
+
+**Pay invoice (simpler — single step):**
+```ts
+export async function sparkPayInvoice(invoice: string): Promise<string> {
+  if (!sdk) throw new Error('Spark wallet not initialized');
+  const result = await sdk.payLightningInvoice({
+    invoice,
+    maxFeeSats: 100,
+  });
+  // Preimage is async in this SDK (call getLightningSendRequest(result.id) to retrieve).
+  // The UI never reads BoostResult.preimage, so returning '' is fine.
+  return '';
+}
+```
+
+`maxFeeSats: 100` is a reasonable hard cap for podcast boosts. Revisit if users report
+payment failures on small amounts — you could compute `Math.max(10, Math.ceil(amountSats * 0.05))`
+if you decode the invoice first, but that adds complexity for little gain.
+
+**Receive invoice:**
+```ts
+export async function sparkReceiveInvoice(args: {
+  amountSats?: number;
+  description?: string;
+}): Promise<{ invoice: string; feeSats: number }> {
+  if (!sdk) throw new Error('Spark wallet not initialized');
+  const result = await sdk.createLightningInvoice({
+    amountSats: args.amountSats ?? 0,
+    memo: args.description ?? 'BoostMeBitch Spark deposit',
+  });
+  return {
+    invoice: result.invoice.encodedInvoice,
+    feeSats: 0,   // Spark Labs SDK doesn't surface the settle fee here
+  };
+}
+```
+
+The `ReadyPanel` in `spark-wallet.tsx` currently shows "Spark settle fee: N sats" when
+`feeSats > 0`. Since `feeSats` will always be 0 now, that line simply never renders —
+no UI change needed there.
+
+**Balance:**
+```ts
+export async function sparkGetInfo(): Promise<{ balanceSats: number; identityPubkey?: string } | null> {
+  if (!sdk) return null;
+  try {
+    const balance = await sdk.getBalance();
+    return { balanceSats: Number(balance.balance) };
+    // identityPubkey is not directly exposed; omitting is fine — nothing reads it.
+  } catch {
+    return null;
+  }
+}
+```
+
+`balance.balance` is a `bigint`. `Number()` is safe for any realistic sat balance.
+
+**Events — EventEmitter pattern replaces async addEventListener:**
+
+The Breez SDK used `addEventListener({ onEvent })` returning a Promise<id>, then
+`removeEventListener(id)`. The Spark Labs SDK is a standard EventEmitter (EventEmitter3).
+
+Map the events callers actually check:
+
+| Breez event | Spark Labs event | Meaning |
+|---|---|---|
+| `paymentSucceeded` | `SparkWalletEvent.BalanceUpdate` | Balance changed after payment |
+| `claimedDeposits` | `SparkWalletEvent.DepositConfirmed` | Deposit settled |
+| `newDeposits` | `SparkWalletEvent.TransferClaimed` | Incoming transfer |
+| `synced` | `SparkWalletEvent.StreamConnected` | Stream ready after init |
+
+```ts
+export async function subscribeSparkEvents(
+  onEvent: (e: SparkSdkEvent) => void,
+): Promise<() => void> {
+  if (!sdk) return () => {};
+
+  const onBalance  = () => onEvent({ type: 'paymentSucceeded', payment: null });
+  const onDeposit  = () => onEvent({ type: 'claimedDeposits', claimedDeposits: [] });
+  const onTransfer = () => onEvent({ type: 'newDeposits', newDeposits: [] });
+  const onStream   = () => onEvent({ type: 'synced' });
+
+  sdk.on(SparkWalletEvent.BalanceUpdate,   onBalance);
+  sdk.on(SparkWalletEvent.DepositConfirmed, onDeposit);
+  sdk.on(SparkWalletEvent.TransferClaimed,  onTransfer);
+  sdk.on(SparkWalletEvent.StreamConnected,  onStream);
+
+  return () => {
+    sdk?.off(SparkWalletEvent.BalanceUpdate,    onBalance);
+    sdk?.off(SparkWalletEvent.DepositConfirmed, onDeposit);
+    sdk?.off(SparkWalletEvent.TransferClaimed,  onTransfer);
+    sdk?.off(SparkWalletEvent.StreamConnected,  onStream);
+  };
+}
+```
+
+This keeps the `SparkSdkEvent` type union and all component event-handler logic
+identical — `spark-wallet.tsx` and `wallet-balance.tsx` don't need to change.
+
+**Disconnect:**
+```ts
+export async function sparkDisconnect(): Promise<void> {
+  if (sdk) {
+    try { await (sdk as any).cleanup(); } catch { /* best effort */ }
+  }
+  sdk = null;
+  activePubkey = null;
+  notify();
+}
+```
+
+The Spark Labs SDK uses `cleanup()` (confirmed in the singleton pattern in wallet.ts).
+Cast to `any` if TypeScript complains — it's a real method.
+
+**Remove from `SparkSdkEvent` union** (types that were never handled):
+- `optimization`
+- `lightningAddressChanged`
+
+Removing them is safe — no component matches on either.
+
+---
+
+### 4. `components/spark-wallet.tsx` — new form, same card
+
+**Delete entirely:**
+- `startCreate` / `confirmCreate` / `cancelCreate` — wallet creation flow
+- `draftMnemonic`, `confirmed` state
+- The "Write this down" seed display block
+- The "Create new" button
+- The "Restore from Nostr" button
+- Import of `sparkGenerateMnemonic`
+
+**Replace the form with:**
+
+A single textarea where the user pastes their BlitzWallet seed phrase, a Connect button,
+and (after successful init) the existing `ReadyPanel`. After connecting, still call
+`publishEncryptedMnemonic` so the seed is saved encrypted to Nostr — this powers the
+silent auto-restore on next login without requiring the user to paste again.
+
+Rough shape:
+
+```tsx
+const [seedInput, setSeedInput] = useState('');
+const [busy, setBusy] = useState(false);
+const [err, setErr] = useState<string | null>(null);
+
+async function connect() {
+  if (!identity) { setErr('Sign in with Nostr first.'); return; }
+  const mnemonic = seedInput.trim();
+  if (!mnemonic) return;
+  setBusy(true); setErr(null);
+  try {
+    storage.sparkOptOut.clear();
+    await sparkInitFromMnemonic({ mnemonic, ownerPubkey: identity.pubkey });
+    // Save encrypted so next login auto-restores without re-pasting.
+    await publishEncryptedMnemonic(identity, mnemonic).catch(() => {});
+    setSeedInput('');
+    onConnected?.();
+  } catch (e) {
+    setErr(getErrorMessage(e, 'failed to connect wallet'));
+  } finally { setBusy(false); }
+}
+
+// render:
+<div className="space-y-2">
+  <div className="text-[11px] text-muted">
+    Paste your BlitzWallet (or any Spark) seed phrase to connect.
+  </div>
+  <textarea
+    className="input w-full text-xs font-mono"
+    rows={3}
+    placeholder="word1 word2 word3 … (12 or 24 words)"
+    value={seedInput}
+    onChange={(e) => setSeedInput(e.target.value)}
+  />
+  <button
+    onClick={connect}
+    disabled={busy || !seedInput.trim() || !identity}
+    className="btn-ghost disabled:opacity-30"
+  >
+    {busy ? 'Connecting…' : 'Connect'}
+  </button>
+  {!identity && <div className="text-[11px] text-muted">Sign in with Nostr first.</div>}
+  {err && <div className="text-[11px] text-nostr/80">{err}</div>}
+</div>
+```
+
+Optionally add basic client-side validation: split by whitespace, check word count is
+12 or 24, show an error before even hitting the SDK. The `@scure/bip39` package
+(already a transitive dep) has `validateMnemonic` if you want full wordlist checking.
+
+---
+
+## What Stays the Same
+
+- `lib/nostr/wallet-backup.ts` — unchanged. `fetchEncryptedMnemonic` powers auto-restore
+  on login; `publishEncryptedMnemonic` is now called after the user pastes their seed.
+- `components/nostr-auth.tsx` — unchanged. The silent auto-restore block at line 114
+  (`sparkPromise = fetchEncryptedMnemonic(id).then(...)`) still works exactly as before.
+- `lib/v4v/wallets.ts` — unchanged.
+- `lib/storage.ts` — unchanged. `sparkOptOut` sentinel still works.
+- `components/wallet-balance.tsx` — unchanged. It calls `subscribeSparkEvents` which
+  still emits the same Breez-named event types (the mapping is internal to spark.ts).
+- `components/wallet-modal.tsx` — unchanged.
+- `lib/v4v/boost.ts` — unchanged. Calls `sparkPayInvoice(invoice)` which still exists.
+
+---
+
+## Things to Watch
+
+**Browser compatibility.** The Spark Labs SDK ships a `dist/index.browser.js` entry and
+uses conditional exports, so Next.js client bundles should pick it up automatically. If
+you see Node.js-only imports (like `net` or `tls`) leaking into the browser bundle, add
+to `next.config.mjs`:
+```js
+webpack: (config, { isServer }) => {
+  if (!isServer) {
+    config.resolve.alias['@buildonspark/spark-sdk'] =
+      require.resolve('@buildonspark/spark-sdk/dist/index.browser.js');
+  }
+  return config;
+},
+```
+
+**`maxFeeSats` on zero-amount invoices.** `payLightningInvoice` requires `maxFeeSats`.
+If someone pays a zero-amount BOLT11 (the `amountSatsToSend` param handles that), the
+`maxFeeSats` cap still applies. 100 sats is fine.
+
+**Existing users with a Breez-derived wallet.** Anyone who created a Spark wallet
+through the old flow has funds at `m/8797555'/1'/…` (Breez's account 1 path). After
+the swap, pasting that same seed will open account 0 — a different, empty wallet. Their
+Breez-path funds aren't lost (the seed still controls them) but they'd need to move
+funds out of the Breez wallet first, or use a different app to access it. Worth a brief
+note in release comms if you have users with existing boostmebitch Spark wallets.
+
+**`@scure/bip39` stays.** It's still used by `lib/nostr/` internals as a transitive dep
+of nostr-tools, so removing Breez won't orphan it. You can still use it for mnemonic
+validation in the paste form if you want.

--- a/docs/spark-sdk-swap.md
+++ b/docs/spark-sdk-swap.md
@@ -298,6 +298,15 @@ webpack: (config, { isServer }) => {
 },
 ```
 
+**Keysend splits will fail — this is expected.** Spark (both Breez and the Labs SDK)
+is BOLT11-only; it cannot keysend. `lib/v4v/boost.ts` already handles this: any
+value-block recipient with `type: 'node'` is rejected per-leg with a clear error, and
+the boost continues to the remaining LNURL/lnaddress recipients. This is unchanged by
+the swap, but worth surfacing to users — a boost to a show where one or more recipients
+are node-pubkey-only will show partial failures. Consider adding a note in the boost
+modal (or the wallet description) along the lines of "Keysend recipients are skipped
+— use NWC if your podcasts require it."
+
 **`maxFeeSats` on zero-amount invoices.** `payLightningInvoice` requires `maxFeeSats`.
 If someone pays a zero-amount BOLT11 (the `amountSatsToSend` param handles that), the
 `maxFeeSats` cap still applies. 100 sats is fine.

--- a/docs/spark-sdk-swap.md
+++ b/docs/spark-sdk-swap.md
@@ -237,7 +237,10 @@ async function connect() {
 // render:
 <div className="space-y-2">
   <div className="text-[11px] text-muted">
-    Paste your BlitzWallet (or any Spark) seed phrase to connect.
+    Works with BlitzWallet, Primal, and any Spark wallet.
+  </div>
+  <div className="text-[11px] text-muted">
+    Paste your seed phrase to connect. Saved once to your Nostr relays — auto-restores on future logins.
   </div>
   <textarea
     className="input w-full text-xs font-mono"

--- a/lib/nostr/relays.ts
+++ b/lib/nostr/relays.ts
@@ -31,6 +31,31 @@ export const PROFILE_RELAYS = [
   'wss://eden.nostr.land',
 ];
 
+// Drop relay entries that aren't valid `ws://` / `wss://` URLs. Corrupt NIP-65
+// tags, stray text, or user typos (e.g. an `r` tag value of
+// `"avatar wss://purplerelay.com"`) otherwise reach nostr-tools' `normalizeURL`,
+// which throws `Invalid URL` synchronously inside `pool.querySync` — that
+// rejection escapes our per-call try/catch and aborts the whole flow (e.g. the
+// Spark "Create new" backup check). A survivor here is guaranteed to parse, so
+// `normalizeURL` can't throw on it. Also dedupes and strips trailing slashes.
+export function sanitizeRelays(urls: string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of urls) {
+    if (typeof raw !== 'string') continue;
+    const url = raw.trim().replace(/\/$/, '');
+    if (!url) continue;
+    try {
+      const u = new URL(url);
+      if (u.protocol !== 'wss:' && u.protocol !== 'ws:') continue;
+    } catch {
+      continue;
+    }
+    if (!seen.has(url)) { seen.add(url); out.push(url); }
+  }
+  return out;
+}
+
 // NIP-65 relay list (kind:10002). We only consume the write side — we never
 // read events from arbitrary relays based on someone's read list, so the
 // parser drops it.
@@ -56,7 +81,7 @@ export async function fetchRelayList(
         const marker = tag[2];
         if (!marker || marker === 'write') write.add(url);
       }
-      return { write: Array.from(write) };
+      return { write: sanitizeRelays(Array.from(write)) };
     } catch {
       return null;
     }
@@ -70,7 +95,11 @@ export async function fetchRelayList(
  */
 export function resolvePublishRelays(identity: NostrIdentity | null): string[] {
   const override = storage.relays.get();
-  if (override) return override.slice(0, 20);
-  if (identity?.writeRelays?.length) return identity.writeRelays.slice(0, 20);
-  return DEFAULT_RELAYS;
+  const chosen = override ?? (identity?.writeRelays?.length ? identity.writeRelays : DEFAULT_RELAYS);
+  // Sanitize regardless of source: a localStorage override or a peer's NIP-65
+  // list can carry a malformed entry. If sanitizing empties the list (every
+  // entry was garbage), fall back to the known-good defaults rather than
+  // returning zero relays.
+  const clean = sanitizeRelays(chosen);
+  return (clean.length ? clean : DEFAULT_RELAYS).slice(0, 20);
 }

--- a/lib/v4v/spark.ts
+++ b/lib/v4v/spark.ts
@@ -1,40 +1,41 @@
 'use client';
 
-// Spark rail — Breez Spark SDK adapter. Self-custodial wallet whose mnemonic
-// is bootstrapped from a NIP-44-encrypted backup on Nostr relays
-// (lib/nostr/wallet-backup.ts).
+// Spark rail — Spark Labs SDK adapter (@buildonspark/spark-sdk). Self-custodial
+// wallet whose mnemonic is bootstrapped from a NIP-44-encrypted backup on Nostr
+// relays (lib/nostr/wallet-backup.ts).
 //
-// Send capabilities: BOLT11 invoices and Spark addresses. Keysend is NOT
-// supported by this rail — node-pubkey value-block legs degrade in
-// lib/v4v/boost.ts. lnaddress legs work because payOne fetches a BOLT11 from
-// the LNURL-pay endpoint first.
+// We use the SDK's per-network DEFAULT account number (1 on mainnet, 0 on
+// regtest) so the SAME seed phrase yields the SAME balance as Primal and
+// BlitzWallet, which both use that default — see CLAUDE.md.
 //
-// Init is two-stage because the SDK ships as a WebAssembly module. The
-// default export of '@breeztech/breez-sdk-spark' is the WASM loader; it
-// must run once before any other SDK call. We dynamic-import inside
-// sparkInitFromMnemonic so the ~1MB WASM payload only lands in the bundle
-// the first time a user actually opens a Spark wallet.
+// Send capabilities: BOLT11 invoices only. Keysend is NOT supported by this
+// rail — node-pubkey value-block legs degrade in lib/v4v/boost.ts. lnaddress
+// legs work because payOne fetches a BOLT11 from the LNURL-pay endpoint first.
+//
+// Init is dynamic-imported inside sparkInitFromMnemonic so the heavy SDK
+// payload only lands in the bundle the first time a user actually opens a
+// Spark wallet.
 
-import { sha256 } from '@noble/hashes/sha2.js';
-import { bytesToHex, utf8ToBytes } from '@noble/hashes/utils.js';
-
-// SDK instance + module references are loosely typed because the SDK's
-// generated wasm bindings change frequently across minor versions; we
-// pin the public surface (hasSpark / sparkPayInvoice / sparkDisconnect)
-// and let TypeScript validate at the call boundary.
+// SDK instance is loosely typed because the SDK's generated bindings change
+// across minor versions; we pin the public surface (hasSpark / sparkPayInvoice /
+// sparkDisconnect / …) and let TypeScript validate at the call boundary.
 type SparkSdk = {
-  sendPayment: (req: any) => Promise<any>;
-  prepareSendPayment: (req: any) => Promise<any>;
-  receivePayment: (req: any) => Promise<any>;
-  disconnect: () => Promise<void>;
-  getInfo: (req: any) => Promise<any>;
-  addEventListener: (listener: { onEvent: (e: SparkSdkEvent) => void }) => Promise<string>;
-  removeEventListener: (id: string) => Promise<boolean>;
+  payLightningInvoice: (req: { invoice: string; maxFeeSats?: number }) => Promise<unknown>;
+  createLightningInvoice: (req: {
+    amountSats: number;
+    memo?: string;
+  }) => Promise<{ invoice?: { encodedInvoice?: string } }>;
+  getBalance: () => Promise<{ balance?: bigint; satsBalance?: { available?: bigint } }>;
+  cleanup: () => Promise<void>;
+  on: (event: string, listener: (...args: unknown[]) => void) => unknown;
+  off: (event: string, listener: (...args: unknown[]) => void) => unknown;
 };
 
-// Mirror of @breeztech/breez-sdk-spark's SdkEvent discriminated union.
-// Re-declared here so callers can subscribe without dragging the SDK
-// types into client components.
+// Consumer-facing event union. Kept intentionally stable across the Breez →
+// Spark Labs swap so components don't change: subscribeSparkEvents maps the
+// SDK's eventemitter3 events into these `type` discriminants. Some variants
+// (e.g. `newDeposits`) are no longer emitted by this SDK — they're harmless
+// dead arms in consumers' switch statements.
 export type SparkSdkEvent =
   | { type: 'synced' }
   | { type: 'unclaimedDeposits'; unclaimedDeposits: unknown[] }
@@ -48,7 +49,6 @@ export type SparkSdkEvent =
 
 let sdk: SparkSdk | null = null;
 let activePubkey: string | null = null;
-let wasmInitialized = false;
 
 // Components reading hasSpark() during render need to refresh when the
 // module-level state flips outside their own tree (e.g. the auto-restore in
@@ -76,88 +76,51 @@ export function sparkOwner(): string | null {
   return activePubkey;
 }
 
-// storageDir suffix derived from the mnemonic so two wallets for the same
-// pubkey (rare but possible: disconnect → create-new with new seed) get
-// different SDK storage directories. Keying on ownerPubkey alone would
-// collide and either fail the second init or corrupt the first wallet.
-function walletStorageDir(ownerPubkey: string, mnemonic: string): string {
-  const walletId = bytesToHex(sha256(utf8ToBytes(mnemonic))).slice(0, 8);
-  return `bmb-spark-${ownerPubkey.slice(0, 8)}-${walletId}`;
-}
-
 /**
  * Initialize the Spark SDK from a BIP-39 mnemonic. Call this once after
- * wallet-backup.ts hands you the decrypted seed, or after a fresh mnemonic
- * is generated for first-time users.
+ * wallet-backup.ts hands you the decrypted seed, after a fresh mnemonic is
+ * generated for first-time users, or when the user pastes an existing seed.
  */
 export async function sparkInitFromMnemonic(args: {
   mnemonic: string;
   ownerPubkey: string;
-  // Spark SDK supports `mainnet` and `regtest` only — there's no public
-  // testnet for Spark. Use `regtest` against a local node for development;
-  // first-boost smoke testing on mainnet with a few sats is the realistic
-  // path.
+  // Spark supports `mainnet` and `regtest` only — there's no public testnet
+  // for Spark. Use `regtest` against a local node for development.
   network?: 'mainnet' | 'regtest';
 }): Promise<void> {
-  const apiKey = process.env.NEXT_PUBLIC_BREEZ_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      'NEXT_PUBLIC_BREEZ_API_KEY is not set. Add it to .env.local and restart the dev server.',
-    );
-  }
+  // Dynamic import keeps the heavy SDK out of the initial bundle.
+  const { SparkWallet } = await import('@buildonspark/spark-sdk');
 
-  // Dynamic import keeps the WASM out of the initial bundle.
-  const mod = await import('@breeztech/breez-sdk-spark');
-  if (!wasmInitialized) {
-    // Default export loads + instantiates the WebAssembly binary. Idempotent
-    // per-load but cheap to guard.
-    await (mod.default as () => Promise<void>)();
-    wasmInitialized = true;
-  }
-
-  const config = mod.defaultConfig(args.network ?? 'mainnet');
-  config.apiKey = apiKey;
-
-  const instance = await mod.connect({
-    config,
-    seed: { type: 'mnemonic', mnemonic: args.mnemonic },
-    storageDir: walletStorageDir(args.ownerPubkey, args.mnemonic),
+  const { wallet } = await SparkWallet.initialize({
+    mnemonicOrSeed: args.mnemonic,
+    // Spark's per-network DEFAULT account number is 1 on mainnet, 0 on regtest.
+    // Primal and BlitzWallet both use that default, so we mirror it explicitly
+    // to derive the SAME account (and therefore share the balance) for a given
+    // seed. Hardcoding 0 on mainnet derives a different, empty account.
+    accountNumber: args.network === 'regtest' ? 0 : 1,
+    options: { network: args.network === 'regtest' ? 'REGTEST' : 'MAINNET' },
   });
 
-  sdk = instance as unknown as SparkSdk;
+  sdk = wallet as unknown as SparkSdk;
   activePubkey = args.ownerPubkey;
   notify();
 }
 
-/** Pay a BOLT11 invoice via the Spark SDK. Returns the payment preimage. */
+/**
+ * Pay a BOLT11 invoice via the Spark SDK. The preimage is NOT returned
+ * synchronously by payLightningInvoice, so we return '' — BoostResult.preimage
+ * is optional and unread by the UI.
+ */
 export async function sparkPayInvoice(invoice: string): Promise<string> {
   if (!sdk) throw new Error('Spark wallet not initialized');
-  // Two-step prepare-then-send is required by the Spark SDK so the caller
-  // could surface fees ahead of the user committing. We don't expose the
-  // estimate today but pass through the prepareResponse as the SDK requires.
-  const prepared = await sdk.prepareSendPayment({ paymentRequest: invoice });
-  const res = await sdk.sendPayment({ prepareResponse: prepared });
-  const payment = res?.payment;
-  if (!payment) throw new Error('Spark sendPayment returned no payment');
-  const status = String(payment.status ?? '').toLowerCase();
-  if (status === 'failed') throw new Error('Spark payment failed');
-  // status: 'completed' | 'pending' both mean the HTLC routed and sats are
-  // committed. preimage is optional on Payment.details.htlcDetails — it's
-  // undefined while htlcStatus === 'waitingForPreimage', which is common at
-  // the moment sendPayment resolves. Don't gate boost success on it; the
-  // BoostResult.preimage field is optional and unread by the UI.
-  const preimage: string =
-    payment.details?.htlcDetails?.preimage ??
-    payment.details?.preimage ??
-    '';
-  return preimage;
+  await sdk.payLightningInvoice({ invoice, maxFeeSats: 100 });
+  return '';
 }
 
 /**
- * Generate a fresh BIP-39 mnemonic. Uses @scure/bip39 directly — the SDK
- * also ships a helper but @scure is already on disk via nostr-tools and
- * produces format-compatible output, so we don't pay the WASM init cost
- * just to mint a phrase.
+ * Generate a fresh BIP-39 mnemonic. Uses @scure/bip39 directly — it's already
+ * on disk via nostr-tools and produces SDK-compatible output, so we don't pay
+ * the SDK init cost just to mint a phrase.
  */
 export async function sparkGenerateMnemonic(): Promise<string> {
   const { generateMnemonic } = await import('@scure/bip39');
@@ -168,62 +131,77 @@ export async function sparkGenerateMnemonic(): Promise<string> {
 /** Tear down the SDK on sign-out. */
 export async function sparkDisconnect(): Promise<void> {
   if (sdk) {
-    try { await sdk.disconnect(); } catch { /* best effort */ }
+    try { await sdk.cleanup(); } catch { /* best effort */ }
   }
   sdk = null;
   activePubkey = null;
   notify();
 }
 
-/** Fetch the wallet's current balance + identity pubkey. */
+/** Fetch the wallet's current balance in sats. */
 export async function sparkGetInfo(): Promise<{ balanceSats: number; identityPubkey?: string } | null> {
   if (!sdk) return null;
   try {
-    const info = await sdk.getInfo({});
-    return {
-      balanceSats: Number(info?.balanceSats ?? 0),
-      identityPubkey: info?.identityPubkey,
-    };
+    const b = await sdk.getBalance();
+    // satsBalance.available is the immediately-spendable balance; `balance` is
+    // the deprecated alias for the same number. Both are bigint.
+    const sats = b?.satsBalance?.available ?? b?.balance ?? 0n;
+    return { balanceSats: Number(sats) };
   } catch {
     return null;
   }
 }
 
 /**
- * Subscribe to SDK events (`paymentSucceeded`, `claimedDeposits`, `synced`,
- * etc.). Returns an unsubscribe fn. Use this instead of polling getInfo —
- * the balance reflects the new state synchronously inside the event,
- * because the SDK has already finished its claim/settle bookkeeping.
+ * Subscribe to SDK events. Maps the SDK's eventemitter3 events into the
+ * consumer-facing SparkSdkEvent union and returns an unsubscribe fn. Use this
+ * instead of polling getInfo.
  */
 export async function subscribeSparkEvents(
   onEvent: (e: SparkSdkEvent) => void,
 ): Promise<() => void> {
   if (!sdk) return () => {};
-  const id = await sdk.addEventListener({ onEvent });
+  const active = sdk;
+
+  // An incoming lightning payment to a deposit invoice surfaces as a claimed
+  // transfer; treat it as a successful payment so ReadyPanel clears the open
+  // invoice and refreshes.
+  const onTransferClaimed = () => onEvent({ type: 'paymentSucceeded', payment: undefined });
+  // On-chain deposits confirming → claimedDeposits (also clears the invoice).
+  const onDepositConfirmed = () => onEvent({ type: 'claimedDeposits', claimedDeposits: [] });
+  // General balance changes + stream (re)connect → a plain refresh.
+  const onBalanceUpdate = () => onEvent({ type: 'synced' });
+  const onStreamConnected = () => onEvent({ type: 'synced' });
+
+  active.on('transfer:claimed', onTransferClaimed);
+  active.on('deposit:confirmed', onDepositConfirmed);
+  active.on('balance:update', onBalanceUpdate);
+  active.on('stream:connected', onStreamConnected);
+
   return () => {
-    if (sdk) sdk.removeEventListener(id).catch(() => {});
+    active.off('transfer:claimed', onTransferClaimed);
+    active.off('deposit:confirmed', onDepositConfirmed);
+    active.off('balance:update', onBalanceUpdate);
+    active.off('stream:connected', onStreamConnected);
   };
 }
 
 /**
  * Generate a BOLT11 invoice the user can pay from any other Lightning wallet
- * to fund this Spark wallet. Returns the invoice string and the fee Spark
- * will charge to settle the incoming payment (in sats).
+ * to fund this Spark wallet. The Spark SDK doesn't surface a settle fee here,
+ * so feeSats is always 0 (ReadyPanel hides the fee line when it's 0).
  */
 export async function sparkReceiveInvoice(args: {
   amountSats?: number;
   description?: string;
 }): Promise<{ invoice: string; feeSats: number }> {
   if (!sdk) throw new Error('Spark wallet not initialized');
-  const res = await (sdk as any).receivePayment({
-    paymentMethod: {
-      type: 'bolt11Invoice',
-      description: args.description ?? 'BoostMeBitch Spark deposit',
-      amountSats: args.amountSats,
-    },
+  const res = await sdk.createLightningInvoice({
+    amountSats: args.amountSats ?? 0,
+    memo: args.description ?? 'BoostMeBitch Spark deposit',
   });
   return {
-    invoice: String(res?.paymentRequest ?? ''),
-    feeSats: Number(res?.fee ?? 0),
+    invoice: String(res?.invoice?.encodedInvoice ?? ''),
+    feeSats: 0,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@breeztech/breez-sdk-spark": "^0.13.6",
+        "@buildonspark/spark-sdk": "^0.8.1",
         "@getalby/sdk": "^5.1.0",
         "@scure/bip39": "^2.0.1",
         "@types/canvas-confetti": "^1.9.0",
@@ -44,17 +44,148 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@breeztech/breez-sdk-spark": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/@breeztech/breez-sdk-spark/-/breez-sdk-spark-0.13.6.tgz",
-      "integrity": "sha512-vu5Zw2UV4Oe2lLxRPqMcPruhAlJTuRLXzf7yButcfj5mZ/Ea4LID1AC7EYwdbGGt8crdMYxu7qgT1U1BbyScKg==",
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@buildonspark/spark-sdk": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@buildonspark/spark-sdk/-/spark-sdk-0.8.1.tgz",
+      "integrity": "sha512-F+aDu14LgMli31QFAGwgTpvHedcW/A7Mvb0/PI+7WoZFjNZYvcMno65Q94/LKVNz3a7GguedkcsWdAa+uDgZWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.2.5",
+        "@lightsparkdev/core": "^1.5.0",
+        "@noble/curves": "^1.9.7",
+        "@noble/hashes": "^1.7.0",
+        "@scure/base": "^1.2.4",
+        "@scure/bip32": "^1.6.2",
+        "@scure/bip39": "^1.5.4",
+        "@scure/btc-signer": "^1.5.0",
+        "abort-controller-x": "^0.4.3",
+        "abortcontroller-polyfill": "^1.7.8",
+        "async-mutex": "^0.5.0",
+        "bare-crypto": "^1.9.2",
+        "bare-fetch": "^3.0.0",
+        "buffer": "^6.0.3",
+        "eventemitter3": "^5.0.1",
+        "js-base64": "^3.7.7",
+        "light-bolt11-decoder": "^3.2.0",
+        "nice-grpc": "^2.1.10",
+        "nice-grpc-client-middleware-retry": "^3.1.10",
+        "nice-grpc-common": "^2.0.2",
+        "nice-grpc-web": "^3.3.7",
+        "ts-proto": "2.8.3",
+        "ua-parser-js": "^2.0.6",
+        "uuidv7": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0",
+        "react-native": ">=0.71.0",
+        "react-native-get-random-values": ">=1.11.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "react-native-get-random-values": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@buildonspark/spark-sdk/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@buildonspark/spark-sdk/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
-        "node": ">=22"
+        "node": "^14.21.3 || >=16"
       },
-      "optionalDependencies": {
-        "better-sqlite3": "^12.2.0",
-        "pg": "^8.18.0"
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@buildonspark/spark-sdk/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@buildonspark/spark-sdk/node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@buildonspark/spark-sdk/node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@buildonspark/spark-sdk/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -214,6 +345,37 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+      "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+      "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@img/colour": {
@@ -721,6 +883,60 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@lightsparkdev/core": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lightsparkdev/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-7EiV/Ld+IqAQJYvSLN2gS6E/UrcCCQ/H4voUz+nAPUDSk8U1P06afTKALh1FeizAXIzqxt1jFQWmQlXPSXmxIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.7",
+        "dayjs": "^1.11.7",
+        "graphql": "^16.6.0",
+        "graphql-ws": "^5.11.3",
+        "ws": "^8.12.1",
+        "zen-observable-ts": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@lightsparkdev/core/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@lightsparkdev/core/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@next/env": {
       "version": "15.5.15",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.15.tgz",
@@ -932,6 +1148,69 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@scure/base": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
@@ -968,6 +1247,57 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/btc-signer": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@scure/btc-signer/-/btc-signer-1.8.1.tgz",
+      "integrity": "sha512-8nX9T++dFyKpvqksNHfSi9CgRsGnHAQtCdIQ1y1GmbCGLpV97v4MUyemUUT6uDumKL3oo3m4niyY6A32nmdLuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5",
+        "micro-packed": "~0.7.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/btc-signer/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -987,7 +1317,6 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1011,6 +1340,48 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/zen-observable": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
+      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller-x": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.4.3.tgz",
+      "integrity": "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA==",
+      "license": "MIT"
+    },
+    "node_modules/abortcontroller-polyfill": {
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
+      "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
+      "license": "MIT"
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
@@ -1040,6 +1411,15 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -1078,6 +1458,316 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-ansi-escapes": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+      "integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.6.5"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-assert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+      "integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.1.2"
+      }
+    },
+    "node_modules/bare-buffer": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/bare-buffer/-/bare-buffer-3.6.0.tgz",
+      "integrity": "sha512-/maRWEQ2eBkVNMbNFVsq1pHXJYVj4Y3AixwruB24eKZDs5Gtu0fixzvjYmBIuTsBMtVH5Yb27pQO9BhFa+IlIQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.20.0"
+      }
+    },
+    "node_modules/bare-crypto": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/bare-crypto/-/bare-crypto-1.14.0.tgz",
+      "integrity": "sha512-k9QAFx67b0IVM0sII8SUbFvjC7oXQhEwkfVC3CcU6C7eaikkJUh2a3PbvQNc4zBx5QvE/zKw7WK2Jlkc7znVRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-assert": "^1.2.0",
+        "bare-stream": "^2.6.3"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-dns": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/bare-dns/-/bare-dns-2.1.4.tgz",
+      "integrity": "sha512-abwjHmpWqSRNB7V5615QxPH92L71AVzFm/kKTs8VYiNTAi2xVdonpv0BjJ0hwXLwomoW+xsSOPjW6PZPO14asg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
+      "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-fetch/-/bare-fetch-3.0.1.tgz",
+      "integrity": "sha512-OWC8Z62E8JmomltTkXt9cCPMPj2DNi2vp66FOj3BkglNKNshZuk8n98Ba3afUxrrM4kv9/eMzh9+U9dXZSQyOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-form-data": "^1.2.0",
+        "bare-http1": "^4.5.2",
+        "bare-https": "^3.0.0",
+        "bare-mime": "^1.0.0",
+        "bare-stream": "^2.9.1",
+        "bare-url": "^2.4.0",
+        "bare-zlib": "^1.3.0"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-form-data": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/bare-form-data/-/bare-form-data-1.2.2.tgz",
+      "integrity": "sha512-DQyAkCf5mgKT07orewuvaJfoalw7RBSHia4wgkrG7+seI6aHLB+r6gMRdCGrlO+BmCqMwgTeHAHxDU2NrOjQnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-buffer": "^3.6.0",
+        "bare-stream": "^2.6.5"
+      }
+    },
+    "node_modules/bare-http-parser": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bare-http-parser/-/bare-http-parser-1.1.4.tgz",
+      "integrity": "sha512-DL+7fTEUWzAEj/Baw9e/BwNAidARbxuUf5bonQ/Wt3VPUdJNyf562ydaono9ZkQBAUw0NydzYEI97rSs/93ruA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-http1": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/bare-http1/-/bare-http1-4.5.6.tgz",
+      "integrity": "sha512-31OAwMkSU+z1VuUOCk65hx3aWQgzCfH/zQ6LGxbJtmiy2Czsw0+uvOBM9YkqaL6zUSTSYG2pLbL0v/TjME3Buw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.6.0",
+        "bare-http-parser": "^1.1.1",
+        "bare-stream": "^2.10.0",
+        "bare-tcp": "^2.2.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-url": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-url": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-https": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-https/-/bare-https-3.0.0.tgz",
+      "integrity": "sha512-W1GRSCzn+xXKf5bMcPs/hg6Ga1bxPqb7owGfS+tvlBQfPe5Q2STcanRuKZrgU60v5uKrhXH5cgWwM+DLqvXZgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-http1": "^4.4.0",
+        "bare-tcp": "^2.2.0",
+        "bare-tls": "^3.0.0"
+      }
+    },
+    "node_modules/bare-inspect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+      "integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.1.0",
+        "bare-type": "^1.0.0"
+      },
+      "engines": {
+        "bare": ">=1.18.0"
+      }
+    },
+    "node_modules/bare-mime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/bare-mime/-/bare-mime-1.0.0.tgz",
+      "integrity": "sha512-lUOswzBkfqham4zjLDueKOd4Qj3gS56BiZ3q2f0g0adoFhF+HFNupvTUfZBWoicl7fWJ7Hp2RUZjmkY47dxxOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-net": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/bare-net/-/bare-net-2.3.1.tgz",
+      "integrity": "sha512-MypSqDKpDU2Xt7FIfazn5yGvRnV09gFcIPHGWstW0gxuzA4tucTcwJSZeos97C4F89vtU5oGwXDN/HrGN6Y4Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.2.2",
+        "bare-pipe": "^4.0.0",
+        "bare-stream": "^2.0.0",
+        "bare-tcp": "^2.0.0"
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-pipe": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/bare-pipe/-/bare-pipe-4.1.5.tgz",
+      "integrity": "sha512-6OfxaG8JSkRh3Gc4hzHRsxNt+yu2PpN7lrv1V+T78GdknWQkVGwiEvu4m+1nbfk8cMVQ0TGxRvQ90XA4rhnTuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.0.0",
+        "bare-stream": "^2.0.0"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-tcp": {
+      "version": "2.2.13",
+      "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.2.13.tgz",
+      "integrity": "sha512-4KQPgqYugvK6QxcSnVGbl87XslBebxmXlv7Glf4M9iwwoSCDKtYmC1t6zsMctTNhzKXbWCId7mB4R9qLWj3JMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-dns": "^2.0.4",
+        "bare-events": "^2.5.4",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/bare-tls": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/bare-tls/-/bare-tls-3.1.5.tgz",
+      "integrity": "sha512-yoOtW3MyJF1mMwavLeuqOE7+qTKZ9cl1GRPxCUOXMUvYCfGltvXyRH48R4EKrRIfgUG6vil6n4Ea1i81fwmgZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-net": "^2.0.1",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.7.0"
+      }
+    },
+    "node_modules/bare-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+      "integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.2.0"
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/bare-zlib": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/bare-zlib/-/bare-zlib-1.3.4.tgz",
+      "integrity": "sha512-Ahr9pfa32rrrrs1ez5mioHS9u+DJUqp98MO88yEJlI9X5SxIuVOli8tbffG8FXwxJbD7imxfDRvwMLsnEteEUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.0.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1096,8 +1786,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.23",
@@ -1112,21 +1801,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1138,28 +1812,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/braces": {
@@ -1209,31 +1861,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
     "node_modules/camelcase-css": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
@@ -1274,6 +1901,18 @@
         "url": "https://www.paypal.me/kirilvatev"
       }
     },
+    "node_modules/case-anything": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/case-anything/-/case-anything-2.1.13.tgz",
+      "integrity": "sha512-zlOQ80VrQ2Ue+ymH5OuM/DlDq64mEm+B9UTdHULv5osUMD6HalNTblf2b1u/m6QecjsnOkBpqVZ+XPwIVsy7Ng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1312,17 +1951,42 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "optional": true
-    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -1355,31 +2019,31 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
+    "node_modules/detect-europe-js": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
+      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1405,6 +2069,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dprint-node": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/dprint-node/-/dprint-node-1.0.8.tgz",
+      "integrity": "sha512-iVKnUtYfGrYcW1ZAlfR/F59cUVL8QIhWoBJoSjkkdua/dkWIgjZfiLMeTjiB06X0ZLkQ0M2C1VbUj/CxkIf1zg==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^1.0.3"
+      }
+    },
+    "node_modules/dprint-node/node_modules/detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "detect-libc": "bin/detect-libc.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
@@ -1412,15 +2097,11 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/end-of-stream": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
-      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "once": "^1.4.0"
-      }
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
@@ -1436,21 +2117,31 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1492,13 +2183,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1526,13 +2210,6 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1558,12 +2235,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT",
-      "optional": true
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -1576,6 +2255,27 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
+      "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-ws": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-5.16.2.tgz",
+      "integrity": "sha512-E1uccsZxt/96jH/OwmLPuXMACILs76pKF2i3W861LpKBCYtGIyPQGtWLuBLkND4ox1KHns70e83PS4te50nvPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "graphql": ">=0.11 <=16"
       }
     },
     "node_modules/hasown": {
@@ -1609,22 +2309,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "optional": true
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1665,6 +2350,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -1688,6 +2382,35 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-standalone-pwa": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
+      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -1697,6 +2420,33 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/light-bolt11-decoder": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/light-bolt11-decoder/-/light-bolt11-decoder-3.2.0.tgz",
+      "integrity": "sha512-3QEofgiBOP4Ehs9BI+RkZdXZNtSys0nsJ6fyGeSiAGCBsMwHGUDS/JQlY/sTnWs91A2Nh0S9XXfA8Sy9g6QpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@scure/base": "1.1.1"
+      }
+    },
+    "node_modules/light-bolt11-decoder/node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -1718,6 +2468,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1726,6 +2488,27 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/micro-packed": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.7.3.tgz",
+      "integrity": "sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/micro-packed/node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/micromatch": {
@@ -1741,36 +2524,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -1801,13 +2554,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/next": {
       "version": "15.5.15",
@@ -1889,18 +2635,65 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+    "node_modules/nice-grpc": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/nice-grpc/-/nice-grpc-2.1.16.tgz",
+      "integrity": "sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
+        "@grpc/grpc-js": "^1.14.0",
+        "abort-controller-x": "^0.5.0",
+        "nice-grpc-common": "^2.0.3"
       }
+    },
+    "node_modules/nice-grpc-client-middleware-retry": {
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/nice-grpc-client-middleware-retry/-/nice-grpc-client-middleware-retry-3.1.15.tgz",
+      "integrity": "sha512-fXfNNdtjCQzc3O/w3WsK1AOU+xdE1V7FCm4FEQWS/UUVsV1616S2oryvWqsZAF8aOvuMir8lFtNmgH3DeP+PBg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller-x": "^0.5.0",
+        "nice-grpc-common": "^2.0.3"
+      }
+    },
+    "node_modules/nice-grpc-client-middleware-retry/node_modules/abort-controller-x": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
+      "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
+      "license": "MIT"
+    },
+    "node_modules/nice-grpc-common": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/nice-grpc-common/-/nice-grpc-common-2.0.3.tgz",
+      "integrity": "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-error": "^1.0.6"
+      }
+    },
+    "node_modules/nice-grpc-web": {
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/nice-grpc-web/-/nice-grpc-web-3.3.10.tgz",
+      "integrity": "sha512-8XyCtbs7uL0mWQEjpkjZy57bnLbtheRbIWgj8p98XPbjFqXOBkTLu+ebj5H4fUu/yxqt+6ULPPDHT/icUsyieA==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller-x": "^0.5.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-base64": "^3.7.2",
+        "nice-grpc-common": "^2.0.3"
+      }
+    },
+    "node_modules/nice-grpc-web/node_modules/abort-controller-x": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
+      "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
+      "license": "MIT"
+    },
+    "node_modules/nice-grpc/node_modules/abort-controller-x": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/abort-controller-x/-/abort-controller-x-0.5.0.tgz",
+      "integrity": "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.38",
@@ -1968,118 +2761,12 @@
         "node": ">= 6"
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
-        "pg-types": "2.2.0",
-        "pgpass": "1.0.5"
-      },
-      "engines": {
-        "node": ">= 16.0.0"
-      },
-      "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
-      },
-      "peerDependencies": {
-        "pg-native": ">=3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "pg-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
-      "license": "MIT",
-      "optional": true,
-      "peerDependencies": {
-        "pg": ">=8.0"
-      }
-    },
-    "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/pg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "postgres-array": "~2.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.4",
-        "postgres-interval": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pgpass": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
-      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "split2": "^4.1.0"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2283,86 +2970,28 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postgres-bytea": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
-      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/protobufjs": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "xtend": "^4.0.0"
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/pump": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
-      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/qrcode.react": {
@@ -2395,22 +3024,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "optional": true,
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -2442,21 +3055,6 @@
         "pify": "^2.3.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2468,6 +3066,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -2526,27 +3133,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -2612,53 +3198,6 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2668,34 +3207,41 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/split2": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
-      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">= 10.x"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+    "node_modules/streamx": {
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
+      "integrity": "sha512-VvNG1K72Po/xwJzxZFnZ++Tbrv4lwSptsbkFuzXCJAYZvCK5nnxsvXU6ajqkv7chyiI1Y0YXq2Jh8Iy8Y7NF/A==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
-      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/styled-jsx": {
@@ -2795,34 +3341,22 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
+        "streamx": "^2.12.5"
       }
     },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/thenify": {
@@ -2909,6 +3443,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-error": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/ts-error/-/ts-error-1.0.6.tgz",
+      "integrity": "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -2916,24 +3456,44 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/ts-poet": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/ts-poet/-/ts-poet-6.12.0.tgz",
+      "integrity": "sha512-xo+iRNMWqyvXpFTaOAvLPA5QAWO6TZrSUs5s4Odaya3epqofBu/fMLHEWl8jPmjhA0s9sgj9sNvF1BmaQlmQkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dprint-node": "^1.0.8"
+      }
+    },
+    "node_modules/ts-proto": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/ts-proto/-/ts-proto-2.8.3.tgz",
+      "integrity": "sha512-TdXInqG+61pj/TvORqITWjvjTTsL1EZxwX49iEj89+xFAcqPT8tjChpAGQXzfcF4MJwvNiuoCEbBOKqVf3ds3g==",
+      "license": "ISC",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "case-anything": "^2.1.13",
+        "ts-poet": "^6.12.0",
+        "ts-proto-descriptors": "2.0.0"
+      },
+      "bin": {
+        "protoc-gen-ts_proto": "protoc-gen-ts_proto"
+      }
+    },
+    "node_modules/ts-proto-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-proto-descriptors/-/ts-proto-descriptors-2.0.0.tgz",
+      "integrity": "sha512-wHcTH3xIv11jxgkX5OyCSFfw27agpInAd6yh89hKG6zqIXnjW9SYqSER2CVQxdPj4czeOhGagNvZBEbJPy7qkw==",
+      "license": "ISC",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -2949,11 +3509,61 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/ua-is-frozen": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
+      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ua-parser-js": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
+      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "AGPL-3.0-or-later",
+      "dependencies": {
+        "detect-europe-js": "^0.1.2",
+        "is-standalone-pwa": "^0.1.1",
+        "ua-is-frozen": "^0.1.2"
+      },
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -2991,24 +3601,106 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC",
-      "optional": true
+    "node_modules/uuidv7": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/uuidv7/-/uuidv7-1.2.1.tgz",
+      "integrity": "sha512-4kPkK3/XTQW9Hbm4CaqfICn+kY9LJtDVEOfgsRRra/+n2Ofg4NqzRFceAkxvQ/Ud/6BpHOPzj8cirqM7TzTN5Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "uuidv7": "cli.js"
+      }
     },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
-      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
       "engines": {
-        "node": ">=0.4"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zen-observable": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.15.tgz",
+      "integrity": "sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==",
+      "license": "MIT"
+    },
+    "node_modules/zen-observable-ts": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
+      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/zen-observable": "0.8.3",
+        "zen-observable": "0.8.15"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@breeztech/breez-sdk-spark": "^0.13.6",
+    "@buildonspark/spark-sdk": "^0.8.1",
     "@getalby/sdk": "^5.1.0",
     "@scure/bip39": "^2.0.1",
     "@types/canvas-confetti": "^1.9.0",


### PR DESCRIPTION
Swaps the Spark wallet rail from `@breeztech/breez-sdk-spark` to `@buildonspark/spark-sdk` so the same seed phrase shares a balance with Primal / BlitzWallet. Fast-forward over `main` — only Spark/wallet/docs files change; no existing features touched.

## What changed
- **`lib/v4v/spark.ts`** — Breez → Spark Labs SDK, same public surface. `SparkWallet.initialize` / `payLightningInvoice` / `createLightningInvoice` / `getBalance` / `cleanup`, with the SDK's eventemitter3 events mapped into the existing `SparkSdkEvent` union.
- **Account number** mirrors the SDK's per-network default (1 on mainnet, 0 on regtest) — Primal and BlitzWallet both use the default, so the same seed derives the same account. No API key needed; `NEXT_PUBLIC_BREEZ_API_KEY` dropped.
- **`components/spark-wallet.tsx`** — paste-seed onboarding alongside Create new and Restore from Nostr.
- **`lib/nostr/relays.ts`** — `sanitizeRelays()` drops malformed relay URLs (a corrupt NIP-65 entry was throwing in nostr-tools' `normalizeURL` and aborting the wallet "Create new" flow).
- Wallet-modal copy/contrast polish; CLAUDE.md + `docs/spark-sdk-swap.md` updated.

## Verification
- Build green (`npm run build`, strict typecheck).
- Paste Primal seed → balance matches Primal/Blitz.
- Boost sends, balance decrements, change reflected in BlitzWallet on mobile (confirms shared Spark account).
- Disconnect → Restore-from-Nostr round-trips the kind:30078 backup.
- Create-new works on a fresh npub (relay-sanitize fix).

## Notes
- No auto-migration from old Breez-derived wallets (Breez used different keys); users paste/restore a seed.
- Known non-fatal Firefox console noise: Spark operators return `Access-Control-Allow-Headers: *`, which doesn't cover the `Authorization` header per the Fetch spec — works today via SDK retries; future browser-enforcement risk is the operator's server config, not ours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)