### PR TITLE
Add full-page episode detail view for better mobile UX

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { Player } from '@/components/player';
 import { NostrAuth } from '@/components/nostr-auth';
 import { GlobalNostrFeed } from '@/components/global-nostr-feed';
 import { DiscussionView } from '@/components/discussion-view';
+import { EpisodeDetailView } from '@/components/episode-detail-view';
 import { DeferredOnScroll } from '@/components/deferred-on-scroll';
 import { BoltIcon } from '@/components/icons';
 import { ThemeToggle } from '@/components/theme-toggle';
@@ -66,6 +67,7 @@ export default function Home() {
   const showLeftRightLayout = loading || feeds.length > 0 || selected || showFavoritesPanel;
   const inDetailView = !!selected;
   const inDiscussion = useApp((s) => !!s.discussionEpisode);
+  const inEpisodeDetail = useApp((s) => !!s.selectedEpisode);
 
   return (
     <main className="min-h-screen pb-32">
@@ -110,6 +112,8 @@ export default function Home() {
       <section className="max-w-7xl mx-auto px-4 pt-2">
         {inDiscussion ? (
           <DiscussionView />
+        ) : inEpisodeDetail ? (
+          <EpisodeDetailView />
         ) : inDetailView ? (
           // Detail "page" — once a podcast is picked, the search/favorites
           // aside hides so the episode list + per-podcast Nostr feed get the

--- a/components/discussion-view.tsx
+++ b/components/discussion-view.tsx
@@ -12,11 +12,12 @@ import { EpisodeSocialThread } from './episode-social-thread';
 export function DiscussionView() {
   const episode = useApp((s) => s.discussionEpisode);
   const closeDiscussion = useApp((s) => s.closeDiscussion);
+  const hasEpisodeDetail = useApp((s) => !!s.selectedEpisode);
   if (!episode?.socialInteract?.length) return null;
   return (
     <div>
       <button onClick={closeDiscussion} className="btn-ghost text-xs mb-3">
-        ← back to episodes
+        {hasEpisodeDetail ? '← back to episode' : '← back to episodes'}
       </button>
       <section className="card p-4">
         <h2 className="font-display text-lg mb-3 truncate">

--- a/components/episode-detail-view.tsx
+++ b/components/episode-detail-view.tsx
@@ -142,6 +142,10 @@ export function EpisodeDetailView() {
   const [boostAllFor, setBoostAllFor] = useState<Episode | null>(null);
   const [valueOpen, setValueOpen] = useState(false);
 
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'instant' });
+  }, [episode?.id]);
+
   if (!episode || !podcast) return null;
 
   const value = episode.value ?? podcast.value;

--- a/components/episode-detail-view.tsx
+++ b/components/episode-detail-view.tsx
@@ -244,7 +244,7 @@ export function EpisodeDetailView() {
               className="stamp text-bolt border-bolt/60 hover:bg-bolt/10 transition cursor-pointer"
               aria-expanded={valueOpen}
             >
-              ⚡ {value.recipients?.length ?? 0} recipients · {value.method}
+              ⚡ {value.recipients?.length ?? 0} recipients
               <span className="ml-1">{valueOpen ? '▾' : '▸'}</span>
             </button>
             {valueOpen && <div className="mt-3"><ValueSplitSection value={value} /></div>}

--- a/components/episode-detail-view.tsx
+++ b/components/episode-detail-view.tsx
@@ -140,6 +140,7 @@ export function EpisodeDetailView() {
 
   const [boostFor, setBoostFor] = useState<Episode | null>(null);
   const [boostAllFor, setBoostAllFor] = useState<Episode | null>(null);
+  const [valueOpen, setValueOpen] = useState(false);
 
   if (!episode || !podcast) return null;
 
@@ -235,7 +236,20 @@ export function EpisodeDetailView() {
         </div>
 
         {/* Value split */}
-        {value && <ValueSplitSection value={value} />}
+        {value && (
+          <div>
+            <button
+              type="button"
+              onClick={() => setValueOpen((v) => !v)}
+              className="stamp text-bolt border-bolt/60 hover:bg-bolt/10 transition cursor-pointer"
+              aria-expanded={valueOpen}
+            >
+              ⚡ {value.recipients?.length ?? 0} recipients · {value.method}
+              <span className="ml-1">{valueOpen ? '▾' : '▸'}</span>
+            </button>
+            {valueOpen && <div className="mt-3"><ValueSplitSection value={value} /></div>}
+          </div>
+        )}
 
         {/* Chapters */}
         {episode.chaptersUrl && (

--- a/components/episode-detail-view.tsx
+++ b/components/episode-detail-view.tsx
@@ -234,6 +234,14 @@ export function EpisodeDetailView() {
           ) : null}
         </div>
 
+        {/* Value split */}
+        {value && <ValueSplitSection value={value} />}
+
+        {/* Chapters */}
+        {episode.chaptersUrl && (
+          <ChaptersList episodeId={episode.id} url={episode.chaptersUrl} />
+        )}
+
         {/* Show notes */}
         {episode.contentEncoded ? (
           <div>
@@ -251,14 +259,6 @@ export function EpisodeDetailView() {
             </div>
           </div>
         ) : null}
-
-        {/* Value split */}
-        {value && <ValueSplitSection value={value} />}
-
-        {/* Chapters */}
-        {episode.chaptersUrl && (
-          <ChaptersList episodeId={episode.id} url={episode.chaptersUrl} />
-        )}
       </section>
 
       {boostFor && (

--- a/components/episode-detail-view.tsx
+++ b/components/episode-detail-view.tsx
@@ -1,0 +1,281 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { useApp } from '@/lib/store';
+import { BoltIcon } from './icons';
+import { PodcastCover } from './podcast-cover';
+import { BoostModal } from './boost-modal';
+import { BoostAllModal } from './boost-all-modal';
+import type { Episode, ValueBlock } from '@/lib/types';
+
+function fmtDuration(t: number) {
+  if (!isFinite(t) || t <= 0) return '';
+  const h = Math.floor(t / 3600);
+  const m = Math.floor((t % 3600) / 60);
+  const s = Math.floor(t % 60).toString().padStart(2, '0');
+  if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${s}`;
+  return `${m}:${s}`;
+}
+
+function stripHtml(s: string): string {
+  return s
+    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
+    .replace(/<\/(p|div|li)\s*>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+interface ChapterEntry {
+  startTime: number;
+  title?: string;
+}
+
+function ChaptersList({ episodeId, url }: { episodeId: number; url: string }) {
+  const [chapters, setChapters] = useState<ChapterEntry[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (chapters !== null || loading) return;
+    setLoading(true);
+    fetch(url)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        const list: ChapterEntry[] = Array.isArray(data?.chapters)
+          ? data.chapters.map((c: { startTime?: unknown; title?: unknown }) => ({
+              startTime: Number(c.startTime) || 0,
+              title: typeof c.title === 'string' ? c.title : undefined,
+            }))
+          : [];
+        setChapters(list);
+      })
+      .catch(() => setChapters([]))
+      .finally(() => setLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [episodeId, url]);
+
+  if (loading && chapters === null) {
+    return <p className="text-xs text-muted">Loading chapters…</p>;
+  }
+  if (!chapters?.length) return null;
+
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-widest text-muted mb-1.5">
+        Chapters ({chapters.length})
+      </p>
+      <ul className="space-y-1 text-xs">
+        {chapters.map((c, i) => (
+          <li key={i} className="flex gap-3 text-bone/80">
+            <span className="text-muted tabular-nums w-12 flex-shrink-0">
+              {fmtDuration(c.startTime)}
+            </span>
+            <span>{c.title ?? `Chapter ${i + 1}`}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ValueSplitSection({ value }: { value: ValueBlock }) {
+  const suggestedSats =
+    value.suggested && Number.isFinite(parseFloat(value.suggested))
+      ? Math.round(parseFloat(value.suggested) * 100_000_000)
+      : null;
+
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-widest text-muted mb-1.5">Value split</p>
+      <div className="text-[11px] text-muted mb-2">
+        {value.type} · {value.method}
+        {suggestedSats !== null && (
+          <span className="text-bolt ml-3">suggested: {suggestedSats} sats/min</span>
+        )}
+      </div>
+      <ul className="space-y-2">
+        {value.recipients.map((r, i) => {
+          const isLnAddr = r.type === 'lnaddress';
+          const addr =
+            isLnAddr || r.address.length <= 20
+              ? r.address
+              : `${r.address.slice(0, 8)}…${r.address.slice(-8)}`;
+          return (
+            <li key={i} className="flex items-start gap-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2 flex-wrap text-sm">
+                  <span className="font-display">
+                    {r.name?.trim() || <span className="text-muted">(unnamed)</span>}
+                  </span>
+                  {r.fee && <span className="stamp text-muted border-bone/30">fee</span>}
+                </div>
+                <div className="text-[11px] text-muted font-mono break-all">{addr}</div>
+              </div>
+              <div className="text-right flex-shrink-0">
+                <div className="font-display text-sm text-bolt">{r.split}</div>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+export function EpisodeDetailView() {
+  const episode = useApp((s) => s.selectedEpisode);
+  const podcast = useApp((s) => s.selectedPodcast);
+  const closeEpisode = useApp((s) => s.closeEpisode);
+  const play = useApp((s) => s.play);
+  const togglePlay = useApp((s) => s.togglePlay);
+  const current = useApp((s) => s.current);
+  const isPlaying = useApp((s) => s.isPlaying);
+  const positionSec = useApp((s) => s.positionSec);
+  const openDiscussion = useApp((s) => s.openDiscussion);
+
+  const [boostFor, setBoostFor] = useState<Episode | null>(null);
+  const [boostAllFor, setBoostAllFor] = useState<Episode | null>(null);
+
+  if (!episode || !podcast) return null;
+
+  const value = episode.value ?? podcast.value;
+  const hasValue = !!value?.recipients?.length;
+  const isThisPlaying = current?.episode.id === episode.id;
+  const description = !episode.contentEncoded && episode.description
+    ? stripHtml(episode.description)
+    : '';
+
+  function handlePlay() {
+    if (isThisPlaying) {
+      togglePlay();
+    } else {
+      play(episode!, podcast!);
+    }
+  }
+
+  return (
+    <div>
+      <button onClick={closeEpisode} className="btn-ghost text-xs mb-3">
+        ← back to episodes
+      </button>
+
+      <section className="card p-4 space-y-5">
+        {/* Artwork */}
+        <div className="flex justify-center pt-2">
+          <PodcastCover
+            image={episode.image ?? podcast.image}
+            artwork={podcast.artwork}
+            title={episode.title}
+            seed={episode.guid ?? String(episode.id)}
+            className="w-48 h-48 sm:w-64 sm:h-64 border border-bone/20 text-5xl"
+          />
+        </div>
+
+        {/* Title & metadata */}
+        <div>
+          <h2 className="font-display text-2xl sm:text-3xl font-semibold leading-tight">
+            {episode.title}
+          </h2>
+          <p className="text-sm text-muted mt-1">{podcast.title}</p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted mt-2">
+            {episode.datePublished && (
+              <span>{new Date(episode.datePublished * 1000).toLocaleDateString()}</span>
+            )}
+            {episode.duration ? <span>· {fmtDuration(episode.duration)}</span> : null}
+            {episode.episode ? <span>· Episode {episode.episode}</span> : null}
+            {episode.season ? <span>· Season {episode.season}</span> : null}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handlePlay}
+            className={`btn ${isThisPlaying ? 'border-bolt text-bolt' : ''}`}
+            aria-label={isThisPlaying && isPlaying ? 'Pause' : isThisPlaying ? 'Resume' : 'Play'}
+          >
+            {isThisPlaying && isPlaying ? '❚❚ PAUSE' : isThisPlaying ? '▶ RESUME' : '▶ PLAY'}
+          </button>
+          {hasValue && (
+            <button
+              type="button"
+              onClick={() => setBoostFor(episode)}
+              className="btn-bolt"
+              aria-label="Boost this episode"
+            >
+              <BoltIcon /> BOOST
+            </button>
+          )}
+          {episode.socialInteract?.length ? (
+            <button
+              type="button"
+              onClick={() => openDiscussion(episode)}
+              className="btn-ghost text-nostr"
+              aria-label="Open episode discussion"
+            >
+              💬 DISCUSSION
+            </button>
+          ) : null}
+          {episode.valueTimeSplits?.length ? (
+            <button
+              type="button"
+              onClick={() => setBoostAllFor(episode)}
+              className="btn-ghost text-bolt text-[11px] uppercase tracking-wider"
+              aria-label={`Boost all ${episode.valueTimeSplits.length} tracks`}
+            >
+              ⚡ Boost {episode.valueTimeSplits.length} tracks
+            </button>
+          ) : null}
+        </div>
+
+        {/* Show notes */}
+        {episode.contentEncoded ? (
+          <div>
+            <p className="text-[11px] uppercase tracking-widest text-muted mb-2">Show notes</p>
+            <div
+              className="show-notes text-sm text-bone/80 leading-relaxed overflow-x-hidden"
+              dangerouslySetInnerHTML={{ __html: episode.contentEncoded }}
+            />
+          </div>
+        ) : description ? (
+          <div>
+            <p className="text-[11px] uppercase tracking-widest text-muted mb-2">Show notes</p>
+            <div className="text-sm text-bone/80 leading-relaxed whitespace-pre-wrap overflow-x-hidden">
+              {description}
+            </div>
+          </div>
+        ) : null}
+
+        {/* Value split */}
+        {value && <ValueSplitSection value={value} />}
+
+        {/* Chapters */}
+        {episode.chaptersUrl && (
+          <ChaptersList episodeId={episode.id} url={episode.chaptersUrl} />
+        )}
+      </section>
+
+      {boostFor && (
+        <BoostModal
+          episode={boostFor}
+          podcast={podcast}
+          positionSec={isThisPlaying ? positionSec : 0}
+          onClose={() => setBoostFor(null)}
+        />
+      )}
+      {boostAllFor && (
+        <BoostAllModal
+          episode={boostAllFor}
+          podcast={podcast}
+          onClose={() => setBoostAllFor(null)}
+        />
+      )}
+    </div>
+  );
+}

--- a/components/episode-detail-view.tsx
+++ b/components/episode-detail-view.tsx
@@ -151,6 +151,7 @@ export function EpisodeDetailView() {
   const value = episode.value ?? podcast.value;
   const hasValue = !!value?.recipients?.length;
   const isThisPlaying = current?.episode.id === episode.id;
+  const playerVisible = !!current;
   const description = !episode.contentEncoded && episode.description
     ? stripHtml(episode.description)
     : '';
@@ -278,6 +279,18 @@ export function EpisodeDetailView() {
           </div>
         ) : null}
       </section>
+
+      {hasValue && (
+        <button
+          type="button"
+          onClick={() => setBoostFor(episode)}
+          className="btn-bolt fixed right-4 z-40 shadow-xl rounded-full"
+          style={{ bottom: `calc(${playerVisible ? '5rem' : '1.5rem'} + env(safe-area-inset-bottom))` }}
+          aria-label="Boost this episode"
+        >
+          <BoltIcon /> BOOST
+        </button>
+      )}
 
       {boostFor && (
         <BoostModal

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -298,7 +298,6 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
   });
   const [loading, setLoading] = useState(false);
   const [showBoostOpen, setShowBoostOpen] = useState(false);
-  const [boostFor, setBoostFor] = useState<Episode | null>(null);
   const [valueOpen, setValueOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const play = useApp((s) => s.play);
@@ -454,33 +453,6 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   <span className="text-bolt text-[11px] mt-0.5">⚡ {e.valueTimeSplits.length} tracks</span>
                 ) : null}
               </div>
-              {e.liveStatus && (e.value ?? data.podcast?.value)?.recipients?.length ? (
-                <button
-                  type="button"
-                  onClick={(ev) => {
-                    ev.stopPropagation();
-                    setBoostFor(e);
-                  }}
-                  className="btn-bolt self-center flex-shrink-0"
-                  title="Boost this live item"
-                >
-                  <BoltIcon />
-                </button>
-              ) : null}
-              {!e.liveStatus && (e.value ?? data.podcast?.value)?.recipients?.length ? (
-                <button
-                  type="button"
-                  onClick={(ev) => {
-                    ev.stopPropagation();
-                    setBoostFor(e);
-                  }}
-                  className="btn-bolt self-center flex-shrink-0"
-                  title="Boost this episode"
-                  aria-label="Boost this episode"
-                >
-                  <BoltIcon />
-                </button>
-              ) : null}
               </div>
             </li>
             </Fragment>
@@ -504,15 +476,6 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
             podcastTitle={data.podcast.title}
           />
         </DeferredOnScroll>
-      )}
-
-      {boostFor && data.podcast && (
-        <BoostModal
-          episode={boostFor}
-          podcast={data.podcast}
-          positionSec={0}
-          onClose={() => setBoostFor(null)}
-        />
       )}
 
       {showBoostOpen && data.podcast && showHasValue && (

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -4,7 +4,6 @@ import type { Episode, Podcast, FavoritePodcast, ValueBlock } from '@/lib/types'
 import { useApp } from '@/lib/store';
 import { resolvePublishRelays, schedulePublishFavorites } from '@/lib/nostr';
 import { BoostModal } from './boost-modal';
-import { BoostAllModal } from './boost-all-modal';
 import { BoltIcon, ShareIcon } from './icons';
 import { PodcastCover } from './podcast-cover';
 import { PodcastNostrFeed } from './podcast-nostr-feed';
@@ -19,30 +18,6 @@ function fmtDuration(t: number) {
   return `${m}:${s}`;
 }
 
-// Render-as-text only — strips tags + decodes a few common entities. Episode
-// descriptions are typically plain text or lightly-tagged HTML; full sanitization
-// isn't needed because we never feed this into dangerouslySetInnerHTML.
-function stripHtml(s: string): string {
-  return s
-    .replace(/<\s*br\s*\/?\s*>/gi, '\n')
-    .replace(/<\/(p|div|li)\s*>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/gi, "'")
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
-}
-
-interface ChapterEntry {
-  startTime: number;
-  title?: string;
-  image?: string;
-  url?: string;
-}
 
 function fmtLiveTime(unixSec: number) {
   const d = new Date(unixSec * 1000);
@@ -317,151 +292,6 @@ function ValueBlockDetails({ value }: { value: ValueBlock }) {
   );
 }
 
-function ChaptersList({
-  episodeId,
-  url,
-  cache,
-  setCache,
-  loadingFor,
-  setLoadingFor,
-}: {
-  episodeId: number;
-  url: string;
-  cache: Map<number, ChapterEntry[]>;
-  setCache: React.Dispatch<React.SetStateAction<Map<number, ChapterEntry[]>>>;
-  loadingFor: number | null;
-  setLoadingFor: React.Dispatch<React.SetStateAction<number | null>>;
-}) {
-  const cached = cache.get(episodeId);
-
-  useEffect(() => {
-    if (cache.has(episodeId)) return;
-    if (loadingFor === episodeId) return;
-    setLoadingFor(episodeId);
-    fetch(url)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-        const list: ChapterEntry[] = Array.isArray(data?.chapters)
-          ? data.chapters.map((c: any) => ({
-              startTime: Number(c.startTime) || 0,
-              title: typeof c.title === 'string' ? c.title : undefined,
-              image: c.img || c.image,
-              url: c.url,
-            }))
-          : [];
-        setCache((prev) => new Map(prev).set(episodeId, list));
-      })
-      .catch(() => setCache((prev) => new Map(prev).set(episodeId, [])))
-      .finally(() => setLoadingFor((cur) => (cur === episodeId ? null : cur)));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [episodeId, url]);
-
-  if (loadingFor === episodeId && !cached) {
-    return <p className="text-xs text-muted">Loading chapters…</p>;
-  }
-  if (!cached?.length) return null;
-
-  return (
-    <div>
-      <p className="text-[11px] uppercase tracking-widest text-muted mb-1.5">
-        Chapters ({cached.length})
-      </p>
-      <ul className="space-y-1 text-xs max-h-60 overflow-y-auto pr-2">
-        {cached.map((c, i) => (
-          <li key={i} className="flex gap-3 text-bone/80">
-            <span className="text-muted tabular-nums w-12 flex-shrink-0">
-              {fmtDuration(c.startTime)}
-            </span>
-            <span className="truncate">{c.title ?? `Chapter ${i + 1}`}</span>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function ExpandedEpisodePanel({
-  episode,
-  podcast,
-  onBoost,
-  chaptersCache,
-  setChaptersCache,
-  chaptersLoading,
-  setChaptersLoading,
-}: {
-  episode: Episode;
-  podcast: Podcast;
-  onBoost: () => void;
-  chaptersCache: Map<number, ChapterEntry[]>;
-  setChaptersCache: React.Dispatch<React.SetStateAction<Map<number, ChapterEntry[]>>>;
-  chaptersLoading: number | null;
-  setChaptersLoading: React.Dispatch<React.SetStateAction<number | null>>;
-}) {
-  const value = episode.value ?? podcast.value;
-  const hasValue = !!value?.recipients?.length;
-  const description = !episode.contentEncoded && episode.description
-    ? stripHtml(episode.description)
-    : '';
-
-  return (
-    <div
-      className="border-t border-bone/10 px-4 py-4 space-y-4 bg-bone/[0.02]"
-      onClick={(ev) => ev.stopPropagation()}
-    >
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted">
-        {episode.datePublished && (
-          <span>{new Date(episode.datePublished * 1000).toLocaleDateString()}</span>
-        )}
-        {episode.duration ? <span>· {fmtDuration(episode.duration)}</span> : null}
-        {episode.episode ? <span>· Episode {episode.episode}</span> : null}
-        {episode.season ? <span>· Season {episode.season}</span> : null}
-      </div>
-
-      {episode.contentEncoded ? (
-        <div
-          className="show-notes text-sm text-bone/80 leading-relaxed max-h-96 overflow-y-auto overflow-x-hidden pr-2"
-          dangerouslySetInnerHTML={{ __html: episode.contentEncoded }}
-        />
-      ) : description ? (
-        <div className="text-sm text-bone/80 leading-relaxed whitespace-pre-wrap overflow-x-hidden max-h-72 overflow-y-auto pr-2">
-          {description}
-        </div>
-      ) : null}
-
-      {value && (
-        <div>
-          <p className="text-[11px] uppercase tracking-widest text-muted mb-1.5">Value split</p>
-          <ValueBlockDetails value={value} />
-        </div>
-      )}
-
-      {episode.chaptersUrl && (
-        <ChaptersList
-          episodeId={episode.id}
-          url={episode.chaptersUrl}
-          cache={chaptersCache}
-          setCache={setChaptersCache}
-          loadingFor={chaptersLoading}
-          setLoadingFor={setChaptersLoading}
-        />
-      )}
-
-      {hasValue && (
-        <button
-          type="button"
-          onClick={(ev) => {
-            ev.stopPropagation();
-            onBoost();
-          }}
-          className="btn-bolt"
-        >
-          <BoltIcon /> BOOST EPISODE
-        </button>
-      )}
-    </div>
-  );
-}
-
 export function EpisodeList({ feedId }: { feedId: number | null }) {
   const [data, setData] = useState<{ podcast: Podcast | null; episodes: Episode[] }>({
     podcast: null, episodes: [],
@@ -469,15 +299,11 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
   const [loading, setLoading] = useState(false);
   const [showBoostOpen, setShowBoostOpen] = useState(false);
   const [boostFor, setBoostFor] = useState<Episode | null>(null);
-  const [boostAllFor, setBoostAllFor] = useState<Episode | null>(null);
   const [valueOpen, setValueOpen] = useState(false);
-  const [expandedId, setExpandedId] = useState<number | null>(null);
-  const [chaptersByEpisode, setChaptersByEpisode] = useState<Map<number, ChapterEntry[]>>(new Map());
-  const [chaptersLoading, setChaptersLoading] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const play = useApp((s) => s.play);
   const current = useApp((s) => s.current);
-  const openDiscussion = useApp((s) => s.openDiscussion);
+  const openEpisode = useApp((s) => s.openEpisode);
 
   useEffect(() => {
     setValueOpen(false);
@@ -568,9 +394,9 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
               )}
             <li
               className={`group transition ${
-                playing ? 'bg-bolt/10' : expandedId === e.id ? 'bg-bone/[0.03]' : 'hover:bg-bone/5'
+                playing ? 'bg-bolt/10' : 'hover:bg-bone/5'
               } cursor-pointer`}
-              onClick={() => setExpandedId((cur) => (cur === e.id ? null : e.id))}
+              onClick={() => openEpisode(e)}
             >
               <div className="flex gap-3 py-3 pr-3">
               <button
@@ -622,31 +448,10 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                   {e.value && <span className="text-bolt">· ⚡ V4V</span>}
                 </div>
                 {e.socialInteract?.length ? (
-                  <button
-                    type="button"
-                    onClick={(ev) => {
-                      ev.stopPropagation();
-                      openDiscussion(e);
-                    }}
-                    className="btn-ghost mt-1 text-nostr text-[11px] px-2 py-0.5 whitespace-nowrap"
-                    title="Open the discussion for this episode"
-                    aria-label="Open episode discussion"
-                  >
-                    💬 discussion
-                  </button>
+                  <span className="text-nostr text-[11px] mt-0.5">💬 discussion</span>
                 ) : null}
                 {e.valueTimeSplits?.length ? (
-                  <button
-                    type="button"
-                    onClick={(ev) => {
-                      ev.stopPropagation();
-                      setBoostAllFor(e);
-                    }}
-                    className="btn-ghost mt-1.5 text-bolt text-[11px] px-2 py-1 whitespace-nowrap uppercase tracking-wider"
-                    title={`Boost all ${e.valueTimeSplits.length} tracks in this episode`}
-                  >
-                    ⚡ Boost {e.valueTimeSplits.length} tracks
-                  </button>
+                  <span className="text-bolt text-[11px] mt-0.5">⚡ {e.valueTimeSplits.length} tracks</span>
                 ) : null}
               </div>
               {e.liveStatus && (e.value ?? data.podcast?.value)?.recipients?.length ? (
@@ -677,17 +482,6 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
                 </button>
               ) : null}
               </div>
-              {expandedId === e.id && data.podcast && (
-                <ExpandedEpisodePanel
-                  episode={e}
-                  podcast={data.podcast}
-                  onBoost={() => setBoostFor(e)}
-                  chaptersCache={chaptersByEpisode}
-                  setChaptersCache={setChaptersByEpisode}
-                  chaptersLoading={chaptersLoading}
-                  setChaptersLoading={setChaptersLoading}
-                />
-              )}
             </li>
             </Fragment>
           );
@@ -728,13 +522,6 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
         />
       )}
 
-      {boostAllFor && data.podcast && (
-        <BoostAllModal
-          episode={boostAllFor}
-          podcast={data.podcast}
-          onClose={() => setBoostAllFor(null)}
-        />
-      )}
     </div>
   );
 }

--- a/components/lists.tsx
+++ b/components/lists.tsx
@@ -352,7 +352,7 @@ export function EpisodeList({ feedId }: { feedId: number | null }) {
               aria-expanded={valueOpen}
               title={valueOpen ? 'Hide split details' : 'Show split details'}
             >
-              ⚡ {data.podcast.value.recipients?.length ?? 0} recipients · {data.podcast.value.method}
+              ⚡ {data.podcast.value.recipients?.length ?? 0} recipients
               <span className="ml-1">{valueOpen ? '▾' : '▸'}</span>
             </button>
           )}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -32,6 +32,13 @@ interface AppState {
   openDiscussion: (e: Episode) => void;
   closeDiscussion: () => void;
 
+  // When set, the page shows a full-screen episode detail view for this
+  // episode (opened from the episode list). Sits between the podcast detail
+  // view and the discussion view in the navigation stack.
+  selectedEpisode: Episode | null;
+  openEpisode: (e: Episode) => void;
+  closeEpisode: () => void;
+
   favorites: Record<string, FavoritePodcast>;
   isFavorite: (guid: string | undefined) => boolean;
   addFavorite: (p: FavoritePodcast) => void;
@@ -67,12 +74,16 @@ export const useApp = create<AppState>((set, get) => ({
 
   selectedPodcast: null,
   // Leaving the detail view (or switching shows) also drops any open
-  // discussion so a stale thread can't outlive its podcast.
-  selectPodcast: (p) => set({ selectedPodcast: p, discussionEpisode: null }),
+  // discussion and episode detail so stale views can't outlive their podcast.
+  selectPodcast: (p) => set({ selectedPodcast: p, discussionEpisode: null, selectedEpisode: null }),
 
   discussionEpisode: null,
   openDiscussion: (e) => set({ discussionEpisode: e }),
   closeDiscussion: () => set({ discussionEpisode: null }),
+
+  selectedEpisode: null,
+  openEpisode: (e) => set({ selectedEpisode: e, discussionEpisode: null }),
+  closeEpisode: () => set({ selectedEpisode: null }),
 
   // Hydrate from the guest cache on store creation; once a user signs in,
   // nostr-auth.tsx replaces this with the per-npub set.


### PR DESCRIPTION
Clicking an episode now opens a dedicated full-page view (fourth
state-driven view, between podcast detail and discussion) instead of
expanding inline in the list. The inline expansion was clunky on mobile
because it pushed rows around and trapped show notes in a capped scroll
area inside an already-scrolling list.

The new EpisodeDetailView shows: large artwork, title, podcast name,
metadata, play/pause/boost/discussion/boost-tracks actions, full
uncapped show notes, value split details, and chapters. Back button
returns to the episode list; discussion opens on top with its own back
button returning to the episode view.

https://claude.ai/code/session_01YLuP535Z6uKo9zhm5BXJEH