### PR TITLE
Add per-episode Nostr boost feed to episode detail view

### DIFF
--- a/components/episode-detail-view.tsx
+++ b/components/episode-detail-view.tsx
@@ -5,6 +5,7 @@ import { BoltIcon } from './icons';
 import { PodcastCover } from './podcast-cover';
 import { BoostModal } from './boost-modal';
 import { BoostAllModal } from './boost-all-modal';
+import { EpisodeNostrFeed } from './episode-nostr-feed';
 import type { Episode, ValueBlock } from '@/lib/types';
 
 function fmtDuration(t: number) {
@@ -279,6 +280,10 @@ export function EpisodeDetailView() {
           </div>
         ) : null}
       </section>
+
+      {episode.guid && (
+        <EpisodeNostrFeed episodeGuid={episode.guid} episodeTitle={episode.title} />
+      )}
 
       {hasValue && (
         <button

--- a/components/episode-nostr-feed.tsx
+++ b/components/episode-nostr-feed.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { useMemo } from 'react';
+import {
+  fetchEpisodeNotes,
+  useNostrFeed,
+  useViewerReposts,
+  type DiscoveredNote,
+} from '@/lib/nostr';
+import { useApp } from '@/lib/store';
+import { FeedSection } from './feed-section';
+import { NoteCard } from './nostr-note-card';
+
+/**
+ * Per-episode Nostr stream — relay query scoped to a single episode via
+ * NIP-73 `#i: podcast:item:guid:<guid>`. Mounted inside <EpisodeDetailView>.
+ */
+export function EpisodeNostrFeed({
+  episodeGuid,
+  episodeTitle,
+}: {
+  episodeGuid: string;
+  episodeTitle?: string;
+}) {
+  const { notes, loading, err, refresh } = useNostrFeed({
+    cacheKey: `episode:${episodeGuid}`,
+    fetcher: (opts) => fetchEpisodeNotes(episodeGuid, opts),
+    deps: [episodeGuid],
+  });
+  const identity = useApp((s) => s.identity);
+  const mutedPubkeys = useApp((s) => s.mutedPubkeys);
+  const repostedIds = useViewerReposts(notes, identity);
+  const visibleNotes = useMemo(
+    () => (notes ? notes.filter((n) => !mutedPubkeys.has(n.pubkey)) : notes),
+    [notes, mutedPubkeys],
+  );
+
+  return (
+    <FeedSection
+      className="mt-8"
+      heading={
+        <h3 className="font-display text-lg">
+          <span className="text-nostr">#</span> Boosts &amp; chatter on Nostr
+          {episodeTitle ? <span className="text-muted text-sm"> · {episodeTitle}</span> : null}
+        </h3>
+      }
+      notes={visibleNotes}
+      loading={loading}
+      err={err}
+      emptyMessage="no nostr boosts for this episode yet — be the first."
+      onRefresh={refresh}
+      renderNote={(n: DiscoveredNote) => (
+        <NoteCard key={n.id} note={n} repostedIds={repostedIds} />
+      )}
+    />
+  );
+}

--- a/lib/nostr/discover.ts
+++ b/lib/nostr/discover.ts
@@ -258,6 +258,33 @@ export async function fetchPodcastNotes(
 }
 
 /**
+ * Fetch every kind:1 note tagged with NIP-73 `podcast:item:guid:<episodeGuid>` from
+ * the given relays. Mirrors fetchPodcastNotes but scoped to a single episode.
+ */
+export async function fetchEpisodeNotes(
+  episodeGuid: string,
+  opts: FetchOpts = {},
+): Promise<DiscoveredNote[]> {
+  const relays = opts.relays ?? DEFAULT_RELAYS;
+  const limit = opts.limit ?? 100;
+
+  return withPool(relays, async (pool) => {
+    let events: Event[] = [];
+    try {
+      events = await pool.querySync(relays, {
+        kinds: [1],
+        '#i': [`podcast:item:guid:${episodeGuid}`],
+        limit,
+        ...(opts.since !== undefined ? { since: opts.since } : {}),
+      }, { maxWait: FEED_QUERY_MAX_WAIT_MS });
+    } catch {
+      return [];
+    }
+    return await assembleNotes(pool, relays, events);
+  });
+}
+
+/**
  * Fetch the Nostr thread referenced by a `<podcast:socialInteract>` URI.
  * Decodes a `nostr:note1…` or `nostr:nevent1…` URI, fetches the root event
  * (using any relay hints embedded in the nevent), then assembles the full

--- a/lib/nostr/index.ts
+++ b/lib/nostr/index.ts
@@ -35,6 +35,7 @@ export {
 export {
   fetchAllPodcastNotes,
   fetchPodcastNotes,
+  fetchEpisodeNotes,
   fetchSocialInteractThread,
   noteFromEvent,
   type DiscoveredNote,


### PR DESCRIPTION
Queries NIP-73 `podcast:item:guid:<guid>` tag so the episode detail
page shows only boosts for that specific episode rather than the full
show feed. Mirrors the existing per-podcast feed pattern exactly.

https://claude.ai/code/session_01VBRX2ppricBrfyDyfmcckT