### PR TITLE
Remove DeferredOnScroll from global feed on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,6 @@ import { NostrAuth } from '@/components/nostr-auth';
 import { GlobalNostrFeed } from '@/components/global-nostr-feed';
 import { DiscussionView } from '@/components/discussion-view';
 import { EpisodeDetailView } from '@/components/episode-detail-view';
-import { DeferredOnScroll } from '@/components/deferred-on-scroll';
 import { BoltIcon } from '@/components/icons';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { useApp } from '@/lib/store';
@@ -174,15 +173,7 @@ export default function Home() {
 
       {!inDetailView && (
         <section className="max-w-7xl mx-auto px-4 pt-12">
-          <DeferredOnScroll
-            placeholder={
-              <h2 className="font-display text-2xl text-muted">
-                <span className="text-nostr">#</span> Global boost feed
-              </h2>
-            }
-          >
-            <GlobalNostrFeed />
-          </DeferredOnScroll>
+          <GlobalNostrFeed />
         </section>
       )}
 


### PR DESCRIPTION
The idle-callback delay (up to 1500ms) was designed to protect competing
resource loads like /api/feed and audio buffering. On the home page with
no podcast selected, there are no such competing loads — the delay just
made the global feed appear broken before relay results arrived.

Per-podcast feeds in lists.tsx keep their DeferredOnScroll wrapper since
they load alongside /api/feed.

https://claude.ai/code/session_01LmTvyd8Wn1PvF9DtSwNhfi