### PR TITLE
Fix NWC backup not auto-restoring on mobile (nostash/iOS)

### DIFF
--- a/components/nostr-auth/index.tsx
+++ b/components/nostr-auth/index.tsx
@@ -64,38 +64,15 @@ export function NostrAuth() {
   }
 
   async function doLoadProfile(id: NostrIdentity) {
-    // Fire all four background refreshes in parallel. Each has a 4s
-    // QUERY_MAX_WAIT_MS bound, so total wall time is ~4s, not the 12-16s
-    // serialized chain it used to be. Mute hydration depends on the bare
-    // identity (npub + pubkey), favorites needs the resolved publish-relay
-    // set ideally — but resolvePublishRelays falls back to DEFAULT_RELAYS
-    // when writeRelays haven't landed yet, so the rare debounced republish
-    // tolerates the race.
+    // Fire profile, relay list, favorites, and mutes in parallel. Each has
+    // a 4s QUERY_MAX_WAIT_MS bound, so total wall time for this phase is ~4s.
+    // Mute/favorites tolerate the bare identity (no writeRelays yet) because
+    // resolvePublishRelays falls back to DEFAULT_RELAYS, which is fine for
+    // the rare debounced republish path.
     const profilePromise = fetchProfile(id.pubkey).catch(() => null);
     const relayListPromise = fetchRelayList(id.pubkey).catch(() => null);
     const favoritesPromise = hydrateFavorites(id).catch(() => {});
     const mutesPromise = hydrateMutes(id).catch(() => {});
-    const sparkPromise = !hasSpark() && !storage.sparkOptOut.get()
-      ? fetchEncryptedMnemonic(id)
-          .then((mnemonic) => {
-            if (mnemonic) return sparkInitFromMnemonic({ mnemonic, ownerPubkey: id.pubkey });
-          })
-          .catch(() => {})
-      : Promise.resolve();
-    // Synced settings: apply the last-used boost rail (relay is the source of
-    // truth on a fresh device; local edits this session re-publish and win).
-    const settingsPromise = fetchSettings(id)
-      .then((s) => { if (s?.railPref) storage.railPref.set(s.railPref); })
-      .catch(() => {});
-    // NWC backup: restore the encrypted connection string if the user opted
-    // in on another device and this device has no NWC URI yet. Mirrors Spark.
-    const nwcPromise = !hasNwc()
-      ? fetchEncryptedNwc(id)
-          .then((uri) => {
-            if (uri) { saveNwcUri(uri); storage.nwcBackup.set(id.npub); }
-          })
-          .catch(() => {})
-      : Promise.resolve();
 
     // Apply profile + relay list as soon as both land. Both feed the
     // identity object, so we wait for them together to avoid two re-renders.
@@ -104,6 +81,32 @@ export function NostrAuth() {
     if (profile) enriched.profile = profile;
     if (relayList?.write?.length) enriched.writeRelays = relayList.write;
     if (profile || relayList?.write?.length) setIdentity(enriched);
+
+    // Wallet restores and settings run with the enriched identity so the
+    // relay query includes the user's actual NIP-65 write relays. Running
+    // them with the bare `id` queries only DEFAULT_RELAYS, silently missing
+    // backups published from a session that had custom write relays — the
+    // primary reason NWC and Spark failed to auto-restore on mobile.
+    const sparkPromise = !hasSpark() && !storage.sparkOptOut.get()
+      ? fetchEncryptedMnemonic(enriched)
+          .then((mnemonic) => {
+            if (mnemonic) return sparkInitFromMnemonic({ mnemonic, ownerPubkey: id.pubkey });
+          })
+          .catch(() => {})
+      : Promise.resolve();
+    // Synced settings: apply the last-used boost rail.
+    const settingsPromise = fetchSettings(enriched)
+      .then((s) => { if (s?.railPref) storage.railPref.set(s.railPref); })
+      .catch(() => {});
+    // NWC backup: restore the encrypted connection string if this device has
+    // no NWC URI yet.
+    const nwcPromise = !hasNwc()
+      ? fetchEncryptedNwc(enriched)
+          .then((uri) => {
+            if (uri) { saveNwcUri(uri); storage.nwcBackup.set(id.npub); }
+          })
+          .catch(() => {})
+      : Promise.resolve();
 
     // Wait for the rest so the dedup map's resolved promise doesn't release
     // before everything settles (in_flight guards re-entrant remounts).

--- a/components/nwc-wallet.tsx
+++ b/components/nwc-wallet.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { hasNwc, saveNwcUri, clearNwcUri, loadNwcUri, nwcValidate } from '@/lib/v4v/nwc';
-import { publishEncryptedNwc, deleteEncryptedNwc, getNip44 } from '@/lib/nostr';
+import { publishEncryptedNwc, deleteEncryptedNwc, fetchEncryptedNwc, getNip44 } from '@/lib/nostr';
 import { useApp } from '@/lib/store';
 import { storage } from '@/lib/storage';
 
@@ -63,6 +63,27 @@ export function NwcWallet({ mode, onConnected, onDisconnected }: Props) {
   const canBackup = !!identity && getNip44() !== null;
 
   function bump() { setTick((t) => t + 1); }
+
+  async function restoreFromNostr() {
+    if (!identity || !canBackup) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const uri = await fetchEncryptedNwc(identity);
+      if (!uri) {
+        setErr('No backup found on Nostr for this account.');
+        return;
+      }
+      saveNwcUri(uri);
+      storage.nwcBackup.set(identity.npub);
+      bump();
+      onConnected?.();
+    } catch (e) {
+      setErr(`Restore failed: ${e instanceof Error ? e.message : 'unknown error'}`);
+    } finally {
+      setBusy(false);
+    }
+  }
 
   async function connect() {
     setErr(null);
@@ -225,6 +246,17 @@ export function NwcWallet({ mode, onConnected, onDisconnected }: Props) {
           {busy ? 'Connecting…' : 'Connect'}
         </button>
       </div>
+      {canBackup && (
+        <div className="border-t border-bone/15 pt-2">
+          <button
+            onClick={restoreFromNostr}
+            disabled={busy}
+            className="text-[11px] text-muted hover:text-bone disabled:opacity-40"
+          >
+            {busy ? 'Restoring…' : '↩ Restore from Nostr backup'}
+          </button>
+        </div>
+      )}
       {err && <div className="text-[11px] text-nostr/80 break-words">{err}</div>}
     </div>
   );

--- a/components/wallet-modal.tsx
+++ b/components/wallet-modal.tsx
@@ -45,6 +45,9 @@ export function WalletModal({ onClose }: Props) {
         const active = getActiveRail();
         if (v.kind === 'connected' && !active) return { kind: 'picker', switching: false };
         if (v.kind === 'picker' && !v.switching && active) return { kind: 'connected' };
+        // Auto-restore completing while the form for that rail is showing:
+        // flip straight to connected without requiring the user to re-paste.
+        if (v.kind === 'connecting' && active === v.rail) return { kind: 'connected' };
         return v;
       });
     };


### PR DESCRIPTION
Three bugs conspired to silently drop the restore:

1. Relay mismatch: NWC, Spark, and settings restores were kicked off
   in parallel with the NIP-65 relay-list fetch, using the bare identity
   (no writeRelays). resolvePublishRelays fell back to DEFAULT_RELAYS, so
   any backup published from a desktop session with custom write relays was
   never found on mobile. Fix: run the three restores after the relay list
   resolves, using the enriched identity.

2. Modal state race: if the auto-restore completed while the wallet modal
   was open and showing the NWC connect form (view.kind === 'connecting'),
   the subscribeNwc bump handler only handled picker → connected, not
   connecting → connected. The modal stayed stuck on the empty form. Fix:
   add the connecting → connected branch.

3. No user-initiated fallback: if auto-restore still fails (signer needs
   user-gesture context, relay query races, etc.), there was no way to
   trigger it manually. Fix: add "↩ Restore from Nostr backup" button to
   the NWC form, visible when signed in with a NIP-44-capable signer.

https://claude.ai/code/session_01S74vxMiwBbZT9G1gugyodc