### PR TITLE
feat: sort music album feeds by disc/track number instead of date

### DIFF
--- a/app/api/feed/route.ts
+++ b/app/api/feed/route.ts
@@ -80,6 +80,9 @@ export async function GET(req: Request) {
     // Within `pending`, sort ascending — the next-to-air show should be at
     // the top of the list. Within `live`, sort descending (most recent
     // broadcast first) on the off chance more than one stream is live.
+    // Music album feeds (medium=music) sort by disc (podcast:season) then
+    // track (podcast:episode) ascending instead of by date.
+    const isMusic = podcast.medium === 'music';
     merged.sort((a, b) => {
       const ra = a.liveStatus ? LIVE_RANK[a.liveStatus] ?? 3 : 3;
       const rb = b.liveStatus ? LIVE_RANK[b.liveStatus] ?? 3 : 3;
@@ -89,6 +92,11 @@ export async function GET(req: Request) {
       }
       if (a.liveStatus && b.liveStatus) {
         return (b.liveStartTime ?? 0) - (a.liveStartTime ?? 0);
+      }
+      if (isMusic) {
+        const seasonDiff = (a.season ?? 1) - (b.season ?? 1);
+        if (seasonDiff !== 0) return seasonDiff;
+        return (a.episode ?? 0) - (b.episode ?? 0);
       }
       return (b.datePublished ?? 0) - (a.datePublished ?? 0);
     });

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -69,6 +69,7 @@ function buildPodcast(f: any): Podcast {
     // <image> but a working <itunes:image>).
     artwork: f.artwork && f.artwork !== f.image ? f.artwork : undefined,
     url: f.url,
+    medium: typeof f.medium === 'string' && f.medium.length > 0 ? f.medium : undefined,
     value: normalizeValue(f.value),
   };
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -51,6 +51,7 @@ export interface Podcast {
    *  second-chance source when `image` fails to load. */
   artwork?: string;
   url?: string;           // RSS feed URL
+  medium?: string;        // podcast:medium (e.g. 'music', 'publisher')
   value?: ValueBlock | null;
 }
 

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -75,8 +75,8 @@ export interface Episode {
   feedTitle?: string;
   feedImage?: string;
   podcastGuid?: string;
-  episode?: number | null;     // <itunes:episode> if present
-  season?: number | null;      // <itunes:season> if present
+  episode?: number | null;     // <podcast:episode> / <itunes:episode> if present
+  season?: number | null;      // <podcast:season> if present (disc number for music)
   chaptersUrl?: string;        // PI exposes Podcasting 2.0 chapters JSON URL
   value?: ValueBlock | null;
   valueTimeSplits?: ValueTimeSplit[];


### PR DESCRIPTION
- Map `medium` from PI feed response in `buildPodcast()` so album feeds
  (podcast:medium=music) are detectable
- In `/api/feed`, sort music feeds by `podcast:season` asc (disc) then
  `podcast:episode` asc (track) instead of `datePublished` desc
- Fix type comments: season/episode fields come from podcast: namespace,
  not itunes: namespace

https://claude.ai/code/session_019uBMhqAvRYie8T2Uexu9rE