### PR TITLE
feat: add Nostr live stream discovery (NIP-53 kind:30311)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import { PodcastResults, EpisodeList, FavoritesList } from '@/components/lists';
 import { Player } from '@/components/player';
 import { NostrAuth } from '@/components/nostr-auth';
 import { GlobalNostrFeed } from '@/components/global-nostr-feed';
+import { NostrLiveStreams } from '@/components/nostr-live-streams';
 import { DiscussionView } from '@/components/discussion-view';
 import { EpisodeDetailView } from '@/components/episode-detail-view';
 import { BoltIcon } from '@/components/icons';
@@ -244,9 +245,14 @@ export default function Home() {
       </section>
 
       {!inDetailView && (
-        <section className="max-w-7xl mx-auto px-4 pt-12">
-          <GlobalNostrFeed />
-        </section>
+        <>
+          <section className="max-w-7xl mx-auto px-4 pt-8">
+            <NostrLiveStreams />
+          </section>
+          <section className="max-w-7xl mx-auto px-4 pt-12">
+            <GlobalNostrFeed />
+          </section>
+        </>
       )}
 
       <Player />

--- a/components/nostr-live-streams.tsx
+++ b/components/nostr-live-streams.tsx
@@ -1,0 +1,263 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import {
+  fetchNostrLiveStreams,
+  resolveStreamV4V,
+  streamToEpisode,
+  streamToPodcast,
+  type NostrLiveStream,
+} from '@/lib/nostr/live-streams';
+import { fetchProfile } from '@/lib/nostr';
+import { storage } from '@/lib/storage';
+import { useApp } from '@/lib/store';
+import type { Episode, Podcast, ValueBlock } from '@/lib/types';
+import { BoostModal } from './boost-modal';
+import { PodcastCover } from './podcast-cover';
+import type { ProfileMetadata } from '@/lib/nostr/auth';
+
+function fmtLiveTime(unixSec: number) {
+  const d = new Date(unixSec * 1000);
+  const today = new Date();
+  const sameDay = d.toDateString() === today.toDateString();
+  const time = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  if (sameDay) return time;
+  return `${d.toLocaleDateString([], { month: 'short', day: 'numeric' })} ${time}`;
+}
+
+interface ResolvedStream {
+  stream: NostrLiveStream;
+  profile: ProfileMetadata | null;
+  value: ValueBlock | null;
+}
+
+export function NostrLiveStreams() {
+  const [resolved, setResolved] = useState<ResolvedStream[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [boostTarget, setBoostTarget] = useState<{ episode: Episode; podcast: Podcast } | null>(null);
+  const play = useApp((s) => s.play);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    load();
+    const timer = setInterval(load, 60_000);
+    const onFocus = () => load();
+    window.addEventListener('focus', onFocus);
+    return () => {
+      mountedRef.current = false;
+      clearInterval(timer);
+      window.removeEventListener('focus', onFocus);
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function load() {
+    try {
+      const streams = await fetchNostrLiveStreams();
+      if (!mountedRef.current) return;
+
+      // Fetch host profiles (needed for name + avatar + LN address)
+      const hostPubkeys = [...new Set(streams.map((s) => s.pubkey))];
+      await Promise.all(
+        hostPubkeys.map(async (pk) => {
+          const cached = storage.profile.get(pk);
+          if (cached === undefined) await fetchProfile(pk);
+        }),
+      );
+
+      // Resolve V4V for each stream (profiles now cached — fast path)
+      const withV4V = await Promise.all(
+        streams.map(async (stream) => {
+          const profile = storage.profile.get(stream.pubkey) ?? null;
+          const value = await resolveStreamV4V(stream);
+          return { stream, profile, value };
+        }),
+      );
+
+      if (!mountedRef.current) return;
+      setResolved(withV4V);
+    } catch {
+      // silently ignore — live streams section just stays empty / stale
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }
+
+  if (loading && !resolved.length) {
+    return (
+      <section>
+        <h3 className="font-display text-lg mb-3 text-bone/70">
+          <span className="text-nostr animate-bolt">●</span> Live on Nostr
+        </h3>
+        <div className="flex gap-3 overflow-x-auto pb-1">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="flex-shrink-0 w-64 h-24 card animate-pulse opacity-40" />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (!resolved.length) return null;
+
+  return (
+    <section>
+      <h3 className="font-display text-lg mb-3 flex items-center gap-2">
+        <span className="text-nostr animate-bolt text-sm">●</span>
+        Live on Nostr
+        <span className="text-[11px] font-mono text-muted uppercase tracking-widest">
+          {resolved.filter((r) => r.stream.status === 'live').length} live
+          {resolved.filter((r) => r.stream.status === 'planned').length > 0 &&
+            ` · ${resolved.filter((r) => r.stream.status === 'planned').length} upcoming`}
+        </span>
+      </h3>
+
+      <div className="flex gap-3 overflow-x-auto pb-2 -mx-1 px-1">
+        {resolved.map(({ stream, profile, value }) => (
+          <StreamCard
+            key={stream.id}
+            stream={stream}
+            profile={profile}
+            value={value}
+            onPlay={() => {
+              play(
+                streamToEpisode(stream, value),
+                streamToPodcast(stream, profile),
+              );
+            }}
+            onBoost={() => {
+              const podcast = streamToPodcast(stream, profile);
+              podcast.value = value;
+              setBoostTarget({
+                episode: streamToEpisode(stream, value),
+                podcast,
+              });
+            }}
+          />
+        ))}
+      </div>
+
+      {boostTarget && (
+        <BoostModal
+          episode={boostTarget.episode}
+          podcast={boostTarget.podcast}
+          onClose={() => setBoostTarget(null)}
+        />
+      )}
+    </section>
+  );
+}
+
+function StreamCard({
+  stream,
+  profile,
+  value,
+  onPlay,
+  onBoost,
+}: {
+  stream: NostrLiveStream;
+  profile: ProfileMetadata | null;
+  value: ValueBlock | null;
+  onPlay: () => void;
+  onBoost: () => void;
+}) {
+  const current = useApp((s) => s.current);
+  const isPlaying = useApp((s) => s.isPlaying);
+  const isCurrentStream =
+    current?.episode.guid === stream.id;
+
+  const displayName =
+    profile?.display_name ?? profile?.name ?? stream.npub.slice(0, 12) + '…';
+  const image = stream.image ?? profile?.picture;
+
+  return (
+    <article className="flex-shrink-0 w-64 card p-3 flex flex-col gap-2">
+      {/* Header row: artwork + status badge */}
+      <div className="flex items-start gap-2">
+        <PodcastCover
+          image={image}
+          title={stream.title}
+          seed={stream.id}
+          className="w-10 h-10 rounded object-cover flex-shrink-0"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1 mb-0.5 flex-wrap">
+            {stream.status === 'live' ? (
+              <span className="stamp text-nostr border-nostr/60 bg-nostr/10 animate-bolt text-[10px] px-1 py-0">
+                ● LIVE
+              </span>
+            ) : (
+              <span className="stamp text-bolt border-bolt/60 text-[10px] px-1 py-0">
+                UPCOMING
+              </span>
+            )}
+            {stream.currentViewers != null && stream.currentViewers > 0 && (
+              <span className="text-[10px] text-muted font-mono">
+                {stream.currentViewers} 👁
+              </span>
+            )}
+          </div>
+          <p className="text-sm font-display leading-tight line-clamp-2" title={stream.title}>
+            {stream.title}
+          </p>
+        </div>
+      </div>
+
+      {/* Host name */}
+      <p className="text-xs text-muted truncate">by {displayName}</p>
+
+      {/* Start time for upcoming streams */}
+      {stream.status === 'planned' && stream.startsAt != null && (
+        <p className="text-xs text-bolt font-mono">
+          starts {fmtLiveTime(stream.startsAt)}
+        </p>
+      )}
+      {stream.status === 'live' && stream.startsAt != null && (
+        <p className="text-xs text-nostr font-mono">
+          started {fmtLiveTime(stream.startsAt)}
+        </p>
+      )}
+
+      {/* Hashtags */}
+      {stream.hashtags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {stream.hashtags.slice(0, 3).map((tag) => (
+            <span key={tag} className="text-[10px] text-muted font-mono bg-bone/5 px-1 rounded">
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Action buttons */}
+      <div className="flex gap-1.5 mt-auto pt-1">
+        <button
+          type="button"
+          onClick={onPlay}
+          disabled={stream.status === 'planned' || !stream.streamUrl}
+          className="btn text-xs py-1 flex-1 disabled:opacity-40 disabled:cursor-not-allowed"
+          title={
+            stream.status === 'planned'
+              ? "Stream hasn't started yet"
+              : !stream.streamUrl
+              ? 'No stream URL'
+              : isCurrentStream && isPlaying
+              ? 'Playing'
+              : 'Play stream'
+          }
+        >
+          {isCurrentStream && isPlaying ? '❚❚' : '▶'} PLAY
+        </button>
+        {value && (
+          <button
+            type="button"
+            onClick={onBoost}
+            className="btn-bolt text-xs py-1 px-2 flex-shrink-0 flex items-center gap-1"
+            title="Boost this stream"
+          >
+            ⚡
+          </button>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/lib/nostr/index.ts
+++ b/lib/nostr/index.ts
@@ -94,3 +94,11 @@ export {
 } from './mutes';
 
 export { hydrateMutes } from './mutes-hydrator';
+
+export {
+  fetchNostrLiveStreams,
+  resolveStreamV4V,
+  streamToEpisode,
+  streamToPodcast,
+  type NostrLiveStream,
+} from './live-streams';

--- a/lib/nostr/live-streams.ts
+++ b/lib/nostr/live-streams.ts
@@ -1,0 +1,234 @@
+import { nip19, type Event } from 'nostr-tools';
+import { withPool, FEED_QUERY_MAX_WAIT_MS } from './pool';
+import { DEFAULT_RELAYS, sanitizeRelays } from './relays';
+import { fetchProfile } from './profile';
+import { storage } from '../storage';
+import type { Episode, Podcast, ValueBlock, ValueRecipient } from '../types';
+import type { ProfileMetadata } from './auth';
+
+// FNV-1a hash for stable numeric IDs (mirrors the one in lib/pi.ts)
+function fnvHash(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h & 0x7fffffff;
+}
+
+export interface NostrLiveStream {
+  /** NIP-33 replaceable address: `${pubkey}:${dTag}` */
+  id: string;
+  eventId: string;
+  dTag: string;
+  pubkey: string;
+  npub: string;
+  title: string;
+  summary?: string;
+  image?: string;
+  /** First `streaming` tag URL — HLS, RTMP, etc. */
+  streamUrl?: string;
+  status: 'live' | 'planned' | 'ended';
+  /** Scheduled/actual start, unix seconds. */
+  startsAt?: number;
+  endsAt?: number;
+  /** `p` tag participants with their declared role. */
+  participants: Array<{ pubkey: string; role: string }>;
+  hashtags: string[];
+  /** NIP-53 `zap` split tags: pubkeys + relative weights for V4V. */
+  zapWeights: Array<{ pubkey: string; relay?: string; weight: number }>;
+  currentViewers?: number;
+  rawEvent: Event;
+}
+
+// Union of DEFAULT_RELAYS and a few extras known to carry kind:30311 events
+// (e.g. zap.stream publishes to these).
+const LIVE_STREAM_RELAYS = sanitizeRelays([
+  ...DEFAULT_RELAYS,
+  'wss://relay.zap.stream',
+  'wss://nostr.wine',
+]);
+
+function parseNostrLiveStream(event: Event): NostrLiveStream {
+  const getTag = (name: string) => event.tags.find((t) => t[0] === name)?.[1];
+  const getAllTags = (name: string) =>
+    event.tags.filter((t) => t[0] === name).map((t) => t[1]).filter(Boolean) as string[];
+
+  const dTag = getTag('d') ?? event.id;
+  const rawStatus = getTag('status') ?? '';
+  const status: NostrLiveStream['status'] =
+    rawStatus === 'live' ? 'live' : rawStatus === 'planned' ? 'planned' : 'ended';
+
+  let npub = '';
+  try { npub = nip19.npubEncode(event.pubkey); } catch { /* ignore */ }
+
+  // NIP-53 zap splits: ["zap", "<pubkey>", "<relay>", "<weight>"]
+  const zapWeights = event.tags
+    .filter((t) => t[0] === 'zap' && typeof t[1] === 'string' && t[1].length === 64)
+    .map((t) => ({
+      pubkey: t[1],
+      relay: t[2] || undefined,
+      weight: parseFloat(t[3] ?? '1') || 1,
+    }));
+
+  return {
+    id: `${event.pubkey}:${dTag}`,
+    eventId: event.id,
+    dTag,
+    pubkey: event.pubkey,
+    npub,
+    title: getTag('title') ?? 'Untitled Stream',
+    summary: getTag('summary') ?? getTag('about'),
+    image: getTag('image') ?? getTag('thumb'),
+    streamUrl: getTag('streaming'),
+    status,
+    startsAt: getTag('starts') ? parseInt(getTag('starts')!, 10) : undefined,
+    endsAt: getTag('ends') ? parseInt(getTag('ends')!, 10) : undefined,
+    participants: event.tags
+      .filter((t) => t[0] === 'p' && typeof t[1] === 'string' && t[1].length === 64)
+      .map((t) => ({ pubkey: t[1], role: t[3] ?? 'participant' })),
+    hashtags: getAllTags('t'),
+    zapWeights,
+    currentViewers: getTag('current_participants')
+      ? parseInt(getTag('current_participants')!, 10)
+      : undefined,
+    rawEvent: event,
+  };
+}
+
+/**
+ * Fetch NIP-53 kind:30311 live stream events from the relay pool.
+ * Returns only live and planned streams, deduplicated by NIP-33 address,
+ * sorted live-first then by start time.
+ */
+export async function fetchNostrLiveStreams(opts?: {
+  limit?: number;
+}): Promise<NostrLiveStream[]> {
+  const { limit = 200 } = opts ?? {};
+  const relays = LIVE_STREAM_RELAYS;
+
+  return withPool(relays, async (pool) => {
+    try {
+      const events = await pool.querySync(
+        relays,
+        {
+          kinds: [30311],
+          // 7-day window catches planned streams scheduled ahead-of-time
+          // without pulling stale ended broadcasts from months ago
+          since: Math.floor(Date.now() / 1000) - 7 * 86400,
+          limit,
+        },
+        { maxWait: FEED_QUERY_MAX_WAIT_MS },
+      );
+
+      // Deduplicate replaceable events: keep the newest version per NIP-33 address
+      const byAddr = new Map<string, Event>();
+      for (const e of events) {
+        const dTag = e.tags.find((t) => t[0] === 'd')?.[1] ?? e.id;
+        const addr = `${e.pubkey}:${dTag}`;
+        const existing = byAddr.get(addr);
+        if (!existing || e.created_at > existing.created_at) {
+          byAddr.set(addr, e);
+        }
+      }
+
+      return Array.from(byAddr.values())
+        .map(parseNostrLiveStream)
+        .filter((s) => s.status === 'live' || s.status === 'planned')
+        .sort((a, b) => {
+          if (a.status !== b.status) return a.status === 'live' ? -1 : 1;
+          return (a.startsAt ?? 0) - (b.startsAt ?? 0);
+        });
+    } catch {
+      return [];
+    }
+  });
+}
+
+/**
+ * Resolve a ValueBlock for V4V boosts against a Nostr live stream.
+ *
+ * Two paths:
+ *  1. If the event has NIP-53 `zap` split tags → resolve each participant's
+ *     Lightning address from their kind:0 profile and build a split ValueBlock.
+ *  2. Most streams have no split tags (single host) → fall back to the host
+ *     pubkey's own Lightning address as the sole 100% recipient.
+ *
+ * Returns null when no resolvable Lightning address is found.
+ */
+export async function resolveStreamV4V(
+  stream: NostrLiveStream,
+): Promise<ValueBlock | null> {
+  // Build the candidate list: zap-split participants, or host as fallback
+  const candidates: Array<{ pubkey: string; relay?: string; weight: number }> =
+    stream.zapWeights.length
+      ? stream.zapWeights
+      : [{ pubkey: stream.pubkey, weight: 1 }];
+
+  const results = await Promise.all(
+    candidates.map(async ({ pubkey, relay, weight }) => {
+      const cached = storage.profile.get(pubkey);
+      let profile: ProfileMetadata | null | undefined = cached;
+      if (profile === undefined) {
+        // Not cached — fetch. Skip known misses (cached === null).
+        const relays = relay ? sanitizeRelays([relay, ...DEFAULT_RELAYS]) : DEFAULT_RELAYS;
+        profile = await fetchProfile(pubkey, relays);
+      }
+      const address = profile?.lud16 ?? profile?.lud06;
+      if (!address) return null;
+      const recipient: ValueRecipient = {
+        name: profile?.display_name ?? profile?.name ?? pubkey.slice(0, 8),
+        type: 'lnaddress',
+        address,
+        split: weight,
+      };
+      return recipient;
+    }),
+  );
+
+  const recipients = results.filter((r): r is ValueRecipient => r !== null);
+  if (!recipients.length) return null;
+  return { type: 'lightning', method: 'lnaddress', recipients };
+}
+
+/**
+ * Convert a NostrLiveStream to an Episode so the existing player, boost modal,
+ * and live-item UI (LiveBadge, seek-bar hiding, "● LIVE streaming now") all
+ * work without modification.
+ */
+export function streamToEpisode(
+  stream: NostrLiveStream,
+  value?: ValueBlock | null,
+): Episode {
+  return {
+    id: fnvHash(stream.id),
+    guid: stream.id,
+    title: stream.title,
+    description: stream.summary,
+    enclosureUrl: stream.streamUrl ?? '',
+    datePublished: stream.startsAt ?? Math.floor(Date.now() / 1000),
+    feedId: 0,
+    liveStatus: stream.status === 'planned' ? 'pending' : stream.status,
+    liveStartTime: stream.startsAt,
+    value: value ?? null,
+  };
+}
+
+/**
+ * Build a synthetic Podcast context for the player. The player stores
+ * `current: { episode, podcast }` so a podcast stub is required even for
+ * standalone live streams that have no PI feed.
+ */
+export function streamToPodcast(
+  stream: NostrLiveStream,
+  hostProfile?: ProfileMetadata | null,
+): Podcast {
+  return {
+    id: 0,
+    title: stream.title,
+    author: hostProfile?.display_name ?? hostProfile?.name ?? stream.npub.slice(0, 12) + '…',
+    description: stream.summary,
+    image: stream.image ?? hostProfile?.picture,
+    artwork: hostProfile?.picture,
+  };
+}


### PR DESCRIPTION
Adds a "Live on Nostr" horizontal scroll section below the search bar
that surfaces active and upcoming kind:30311 live streams from the relay
pool, with V4V boost support via the host's Lightning address.

- lib/nostr/live-streams.ts: fetch + parse kind:30311 events;
  resolveStreamV4V falls back to host's lud16/lud06 when no zap-split
  tags are present (covers the common single-host case the user noted);
  streamToEpisode/streamToPodcast convert to the existing Episode+Podcast
  types so the player, live badges, and boost modal all work unchanged.

- components/nostr-live-streams.tsx: stream cards with thumbnail, status
  badge (● LIVE / UPCOMING), host name, start time, hashtag chips, PLAY
  and ⚡ BOOST buttons; section hidden when no streams are found; auto-
  refreshes every 60s and on window focus.

- app/page.tsx: render <NostrLiveStreams /> in browse mode above the
  global Nostr feed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XQPNHMMU9YcWFKprHKZeu2