### PR TITLE
Optimize live loading: RSS fetch dedupe/cache, persistent + health-scored Nostr pool, feed racing

### DIFF
--- a/lib/nostr/discover.ts
+++ b/lib/nostr/discover.ts
@@ -1,9 +1,10 @@
 import { nip19, type Event } from 'nostr-tools';
-import { withPool, withExtraRelays, FEED_QUERY_MAX_WAIT_MS, QUERY_MAX_WAIT_MS } from './pool';
+import { withPool, withExtraRelays, FEED_QUERY_MAX_WAIT_MS, FEED_QUIET_MS, QUERY_MAX_WAIT_MS } from './pool';
 import { DEFAULT_RELAYS, PROFILE_RELAYS, sanitizeRelays } from './relays';
 import { storage } from '../storage';
 import { parseProfileContent, type ProfileMetadata } from './auth';
 import { collectEventsByAuthors } from './event-queries';
+import { warmRelays } from './relay-health';
 import { bolt11AmountMsat } from '../v4v/bolt11';
 import { stripNostrUris, extractImages } from '../format';
 
@@ -248,18 +249,21 @@ export async function fetchPodcastNotes(
   ];
 
   return withPool(relays, async (pool) => {
+    // Drop dead/penalty-boxed relays so the scan isn't pinned by one of them,
+    // then race the live set with a quiet-period early resolve.
+    const live = await warmRelays(pool, relays);
     let events: Event[] = [];
     try {
-      events = await pool.querySync(relays, {
+      ({ events } = await collectEventsByAuthors(pool, live, {
         kinds: [1],
         '#i': iTags,
         limit,
         ...(opts.since !== undefined ? { since: opts.since } : {}),
-      }, { maxWait: FEED_QUERY_MAX_WAIT_MS });
+      }, [], FEED_QUERY_MAX_WAIT_MS, FEED_QUIET_MS));
     } catch {
       return [];
     }
-    return await assembleNotes(pool, relays, events);
+    return await assembleNotes(pool, live, events);
   });
 }
 
@@ -275,18 +279,19 @@ export async function fetchEpisodeNotes(
   const limit = opts.limit ?? 100;
 
   return withPool(relays, async (pool) => {
+    const live = await warmRelays(pool, relays);
     let events: Event[] = [];
     try {
-      events = await pool.querySync(relays, {
+      ({ events } = await collectEventsByAuthors(pool, live, {
         kinds: [1],
         '#i': [`podcast:item:guid:${episodeGuid}`],
         limit,
         ...(opts.since !== undefined ? { since: opts.since } : {}),
-      }, { maxWait: FEED_QUERY_MAX_WAIT_MS });
+      }, [], FEED_QUERY_MAX_WAIT_MS, FEED_QUIET_MS));
     } catch {
       return [];
     }
-    return await assembleNotes(pool, relays, events);
+    return await assembleNotes(pool, live, events);
   });
 }
 
@@ -364,18 +369,19 @@ export async function fetchAllPodcastNotes(
   const limit = opts.limit ?? 100;
 
   return withPool(relays, async (pool) => {
+    const live = await warmRelays(pool, relays);
     let events: Event[] = [];
     try {
-      events = await pool.querySync(relays, {
+      ({ events } = await collectEventsByAuthors(pool, live, {
         kinds: [1],
         '#k': ['podcast:guid', 'podcast:item:guid'],
         limit,
         ...(opts.since !== undefined ? { since: opts.since } : {}),
-      }, { maxWait: FEED_QUERY_MAX_WAIT_MS });
+      }, [], FEED_QUERY_MAX_WAIT_MS, FEED_QUIET_MS));
     } catch {
       return [];
     }
-    return await assembleNotes(pool, relays, events);
+    return await assembleNotes(pool, live, events);
   });
 }
 

--- a/lib/nostr/event-queries.ts
+++ b/lib/nostr/event-queries.ts
@@ -74,6 +74,9 @@ export interface CollectResult {
  * Resolves at the earliest of:
  *   - every pubkey in `expectedAuthors` seen at least once (all-found early exit),
  *   - aggregate EOSE (every relay reached end-of-stored-events),
+ *   - `quietMs` after the last event arrived (set > 0 to enable — backstops a
+ *     connected-but-stalled relay that never sends EOSE; leave 0 for the
+ *     profile path, which relies on the all-found exit + EOSE),
  *   - `maxWait`.
  *
  * Unlike `pool.querySync` (which waits for the slowest relay or the full maxWait
@@ -95,6 +98,7 @@ export async function collectEventsByAuthors(
   filter: Filter,
   expectedAuthors: string[],
   maxWait = FEED_QUERY_MAX_WAIT_MS,
+  quietMs = 0,
 ): Promise<CollectResult> {
   const byId = new Map<string, Event>();
   const seenAuthors = new Set<string>();
@@ -103,12 +107,21 @@ export async function collectEventsByAuthors(
 
   await new Promise<void>((resolve) => {
     let settled = false;
+    let quietTimer: ReturnType<typeof setTimeout> | null = null;
     const finish = () => {
       if (settled) return;
       settled = true;
       clearTimeout(hardTimer);
+      if (quietTimer) clearTimeout(quietTimer);
       try { sub?.close(); } catch { /* already closed */ }
       resolve();
+    };
+    // (Re)arm the quiet-period timer on each event so the scan resolves once
+    // the live relays stop trickling, rather than waiting out the slowest one.
+    const bumpQuiet = () => {
+      if (quietMs <= 0) return;
+      if (quietTimer) clearTimeout(quietTimer);
+      quietTimer = setTimeout(finish, quietMs);
     };
 
     const hardTimer = setTimeout(finish, maxWait);
@@ -123,6 +136,7 @@ export async function collectEventsByAuthors(
         onevent(e: Event) {
           if (!byId.has(e.id)) byId.set(e.id, e);
           seenAuthors.add(e.pubkey);
+          bumpQuiet();
           // All-found early exit: stop the moment every requested author has a
           // matching event in hand — no reason to wait on slow relays.
           if (want.size > 0 && seenAuthors.size >= want.size) {

--- a/lib/nostr/pool.ts
+++ b/lib/nostr/pool.ts
@@ -17,6 +17,15 @@ import { SimplePool } from 'nostr-tools';
 export const QUERY_MAX_WAIT_MS = 4000;
 export const FEED_QUERY_MAX_WAIT_MS = 8000;
 
+// Quiet-period early-resolve for broad feed scans. Once events have started
+// arriving, if none of the live relays sends a new one for this long, the scan
+// resolves rather than waiting out FEED_QUERY_MAX_WAIT_MS for a connected-but-
+// stalled relay that never sends EOSE. Generous enough not to truncate normal
+// trickle from a slow-but-healthy relay; far under the hard ceiling. Paired
+// with warmRelays (relay-health.ts), which has already dropped dead relays, so
+// the remaining set should go quiet quickly when genuinely done.
+export const FEED_QUIET_MS = 2500;
+
 // A single long-lived pool reused across every read query and publish. Relay
 // WebSockets live inside the pool keyed by URL, so a second query to the same
 // relay rides the already-open socket instead of paying a fresh TLS+WS

--- a/lib/nostr/pool.ts
+++ b/lib/nostr/pool.ts
@@ -17,28 +17,45 @@ import { SimplePool } from 'nostr-tools';
 export const QUERY_MAX_WAIT_MS = 4000;
 export const FEED_QUERY_MAX_WAIT_MS = 8000;
 
-// Wraps `new SimplePool()` + `pool.close()` so callers can't forget the
-// teardown. Used for every kind:0 / 10002 / 30003 query and every publish.
+// A single long-lived pool reused across every read query and publish. Relay
+// WebSockets live inside the pool keyed by URL, so a second query to the same
+// relay rides the already-open socket instead of paying a fresh TLS+WS
+// handshake — the dominant, variable latency on flaky networks. (This is
+// nostr-tools' intended usage: a SimplePool is built once and kept; it
+// reconnects dropped relays on the next query on its own.) Lazily constructed
+// so importing this module during SSR doesn't build a pool the server never
+// uses.
+let sharedPool: SimplePool | null = null;
+function getSharedPool(): SimplePool {
+  if (!sharedPool) sharedPool = new SimplePool();
+  return sharedPool;
+}
+
+// Runs `fn` against the shared pool. Used for every kind:0 / 10002 / 30003
+// query and every publish. Deliberately does NOT close the pool's relays
+// afterwards — that's what the old create-per-query version did, throwing away
+// every warm connection on each call. The only sockets still torn down are the
+// one-off extras opened by `withExtraRelays`, which bounds the persistent set
+// to the relays we actually want to keep warm. `relays` is now unused here
+// (callers pass their own relay list to querySync/subscribeMany inside `fn`),
+// but the signature is kept so callers read unchanged.
 export async function withPool<T>(
-  relays: string[],
+  _relays: string[],
   fn: (pool: SimplePool) => Promise<T>,
 ): Promise<T> {
-  const pool = new SimplePool();
-  try {
-    return await fn(pool);
-  } finally {
-    pool.close(relays);
-  }
+  return fn(getSharedPool());
 }
 
 /**
  * Run `fn` with the union of `baseRelays` + `extraRelays` (deduped),
  * closing only the newly-opened extras when done. Use inside a `withPool`
- * scope when a sub-query needs extra relays beyond the outer base set so
- * the extras are torn down before the outer pool exits — otherwise their
- * sockets leak past the surrounding `withPool.finally` (which only closes
- * its own relay list). Close errors are swallowed since extras going down
- * mid-query is a normal condition we never want to propagate.
+ * scope when a sub-query needs extra relays beyond the outer base set. The
+ * shared pool is never closed, so these one-off extras (quote-ref hints,
+ * other authors' write relays, nevent hints) MUST be torn down here or they
+ * accumulate open sockets for the life of the tab — closing them keeps the
+ * persistent connection set bounded to the relays we actually reuse. Close
+ * errors are swallowed since extras going down mid-query is a normal
+ * condition we never want to propagate.
  */
 export async function withExtraRelays<T>(
   pool: SimplePool,

--- a/lib/nostr/relay-health.ts
+++ b/lib/nostr/relay-health.ts
@@ -1,0 +1,100 @@
+import type { SimplePool } from 'nostr-tools';
+
+// Passive relay-health tracking for the read-query paths. A relay in the
+// 20-relay union that's unreachable or AUTH-gated otherwise pads every feed
+// query out to the full FEED_QUERY_MAX_WAIT_MS, because querySync/subscribeMany
+// wait on the slowest relay. Here we record connection outcomes and put a
+// chronically-failing relay in a penalty box so it's skipped entirely for a
+// cooldown — a single dead relay stops taxing every navigation.
+//
+// The signal is connection success/failure via `pool.ensureRelay` (see
+// `warmRelays`), which is the only per-relay outcome SimplePool exposes
+// cleanly; a successful connect resets a relay's score. Module-level state, so
+// it's shared across every query for the life of the tab (alongside the shared
+// pool in pool.ts). Browser-only — `Date.now()` is fine here.
+
+interface RelayHealth {
+  /** Consecutive connection failures since the last success. */
+  fails: number;
+  /** Unix-ms; while `Date.now() < until` the relay is penalty-boxed (skipped). */
+  until: number;
+}
+
+// Two strikes before benching — a single transient blip (relay restart, a
+// flaky socket on app-switch) shouldn't sideline an otherwise-good relay.
+const FAIL_THRESHOLD = 2;
+// Cooldown grows with each failure past the threshold so a truly-dead relay is
+// retried rarely, but a recovering one comes back within a minute.
+const BASE_COOLDOWN_MS = 60_000;
+const MAX_COOLDOWN_MS = 10 * 60_000;
+// Per-relay connection probe budget. Comfortably under the feed query's own
+// maxWait so warming a cold/slow relay never dominates, but long enough that a
+// healthy-but-distant relay isn't falsely benched.
+const CONNECT_TIMEOUT_MS = 3000;
+
+const health = new Map<string, RelayHealth>();
+
+/** Record a connection outcome for `url`. Success clears the score; failure
+ *  increments it and, past the threshold, extends the penalty box with
+ *  exponential backoff (capped). */
+export function markRelay(url: string, ok: boolean): void {
+  if (ok) {
+    if (health.has(url)) health.delete(url);
+    return;
+  }
+  const prev = health.get(url) ?? { fails: 0, until: 0 };
+  const fails = prev.fails + 1;
+  let until = prev.until;
+  if (fails >= FAIL_THRESHOLD) {
+    const cooldown = Math.min(
+      BASE_COOLDOWN_MS * 2 ** (fails - FAIL_THRESHOLD),
+      MAX_COOLDOWN_MS,
+    );
+    until = Date.now() + cooldown;
+  }
+  health.set(url, { fails, until });
+}
+
+/** Drop relays currently in the penalty box. Never returns empty: if every
+ *  candidate is benched (total outage / offline), returns the original list so
+ *  the query still attempts and the caller's own timeout governs — being
+ *  pessimistic to the point of querying nothing would be worse than trying. */
+export function healthyRelays(relays: string[]): string[] {
+  const now = Date.now();
+  const ok = relays.filter((r) => (health.get(r)?.until ?? 0) <= now);
+  return ok.length ? ok : relays;
+}
+
+/**
+ * Connect (or reuse an existing connection to) each non-benched relay in
+ * parallel, record the outcome, and return the relays that are live. With the
+ * shared persistent pool, already-open sockets resolve instantly, so this
+ * mostly costs time only for relays that are actually down — and that cost is
+ * bounded by CONNECT_TIMEOUT_MS (well under the query's maxWait it would
+ * otherwise stall) and paid at most once before the relay is benched.
+ *
+ * The returned set is what the caller should query: dead relays are excluded
+ * so subscribeMany's aggregate EOSE fires on the live relays alone instead of
+ * waiting out the timeout. Never returns empty (same fallback as
+ * `healthyRelays`).
+ */
+export async function warmRelays(
+  pool: SimplePool,
+  relays: string[],
+): Promise<string[]> {
+  const candidates = healthyRelays(relays);
+  const outcomes = await Promise.all(
+    candidates.map(async (url) => {
+      try {
+        await pool.ensureRelay(url, { connectionTimeout: CONNECT_TIMEOUT_MS });
+        markRelay(url, true);
+        return url;
+      } catch {
+        markRelay(url, false);
+        return null;
+      }
+    }),
+  );
+  const live = outcomes.filter((u): u is string => u !== null);
+  return live.length ? live : candidates;
+}

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -224,6 +224,38 @@ export async function getLiveItemsForFeed(feedId: number): Promise<Episode[]> {
   return out;
 }
 
+// Short-lived in-memory cache of raw feed XML, keyed by URL. A single
+// feed-page load parses the same feed twice — once for episode enrichment
+// (socialInteract / show notes / track order) and once for live items — and
+// the /api/feed route awaits them in sequence, so without this the same URL
+// is fetched (and re-downloaded) back-to-back. The first parse populates the
+// cache; the second is an instant hit. The window also collapses repeat
+// requests for the same feed across page loads. 60s matches the
+// `next: { revalidate }` below, so this and Next's data cache expire together.
+// Only successful bodies are cached — a transient fetch failure is retried.
+const RSS_XML_TTL_MS = 60_000;
+const rssXmlCache = new Map<string, { xml: string; expires: number }>();
+
+async function fetchFeedXml(rssUrl: string): Promise<string | null> {
+  const hit = rssXmlCache.get(rssUrl);
+  if (hit && hit.expires > Date.now()) return hit.xml;
+  let res: Response;
+  try {
+    assertSafeFetchUrl(rssUrl);
+    res = await fetch(rssUrl, {
+      headers: { 'User-Agent': process.env.APP_NAME ?? 'boostmebitch/0.1' },
+      next: { revalidate: 60 },
+      signal: AbortSignal.timeout(8000),
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+  const xml = await res.text();
+  rssXmlCache.set(rssUrl, { xml, expires: Date.now() + RSS_XML_TTL_MS });
+  return xml;
+}
+
 // PI's /episodes/live only indexes currently-broadcasting items; pending
 // liveItems live exclusively in the publisher's RSS. Fetch the feed XML
 // and pull <podcast:liveItem status="pending|live"> directly.
@@ -236,19 +268,8 @@ export async function getLiveItemsFromRss(
   feedId: number,
   podcastGuid?: string,
 ): Promise<Episode[]> {
-  let res: Response;
-  try {
-    assertSafeFetchUrl(rssUrl);
-    res = await fetch(rssUrl, {
-      headers: { 'User-Agent': process.env.APP_NAME ?? 'boostmebitch/0.1' },
-      next: { revalidate: 60 },
-      signal: AbortSignal.timeout(8000),
-    });
-  } catch {
-    return [];
-  }
-  if (!res.ok) return [];
-  const xml = await res.text();
+  const xml = await fetchFeedXml(rssUrl);
+  if (xml == null) return [];
   return parseRssLiveItems(xml).map((r): Episode => ({
     id: -fnvHash(r.guid ?? r.title ?? `${rssUrl}#${r.startTime ?? ''}`),
     guid: r.guid,
@@ -440,19 +461,8 @@ export async function getRssEpisodeEnrichment(
   rssUrl: string,
 ): Promise<RssFeedEnrichment> {
   const episodes = new Map<string, RssEpisodeEnrichment>();
-  let res: Response;
-  try {
-    assertSafeFetchUrl(rssUrl);
-    res = await fetch(rssUrl, {
-      headers: { 'User-Agent': process.env.APP_NAME ?? 'boostmebitch/0.1' },
-      next: { revalidate: 60 },
-      signal: AbortSignal.timeout(8000),
-    });
-  } catch {
-    return { episodes };
-  }
-  if (!res.ok) return { episodes };
-  const xml = await res.text();
+  const xml = await fetchFeedXml(rssUrl);
+  if (xml == null) return { episodes };
 
   // Channel-level podcast:medium (before first <item>)
   const firstItem = xml.search(/<item\b/i);

--- a/lib/pi.ts
+++ b/lib/pi.ts
@@ -224,36 +224,51 @@ export async function getLiveItemsForFeed(feedId: number): Promise<Episode[]> {
   return out;
 }
 
-// Short-lived in-memory cache of raw feed XML, keyed by URL. A single
-// feed-page load parses the same feed twice — once for episode enrichment
-// (socialInteract / show notes / track order) and once for live items — and
-// the /api/feed route awaits them in sequence, so without this the same URL
-// is fetched (and re-downloaded) back-to-back. The first parse populates the
-// cache; the second is an instant hit. The window also collapses repeat
-// requests for the same feed across page loads. 60s matches the
-// `next: { revalidate }` below, so this and Next's data cache expire together.
-// Only successful bodies are cached — a transient fetch failure is retried.
-const RSS_XML_TTL_MS = 60_000;
-const rssXmlCache = new Map<string, { xml: string; expires: number }>();
+// In-memory cache of raw feed XML, keyed by URL. A single feed-page load
+// parses the same feed twice — once for episode enrichment (socialInteract /
+// show notes / track order) and once for live items — and the /api/feed route
+// awaits them in sequence, so without this the same URL is fetched (and
+// re-downloaded) back-to-back. The first parse populates the cache; the second
+// is an instant hit. The window also collapses repeat requests for the same
+// feed across page loads.
+//
+// Two-tier freshness:
+//   - within FRESH window: serve cached XML without refetching (matches the
+//     `next: { revalidate: 60 }` below, so this and Next's data cache align).
+//   - past FRESH but within STALE: refetch; if the refetch FAILS, serve the
+//     last-known-good copy rather than blanking the feed's live items /
+//     enrichment on a transient publisher outage (stale-while-error).
+// A successful fetch always replaces the cached copy and resets both windows.
+const RSS_FRESH_MS = 60_000;
+const RSS_STALE_MS = 10 * 60_000;
+const rssXmlCache = new Map<string, { xml: string; fetchedAt: number }>();
 
 async function fetchFeedXml(rssUrl: string): Promise<string | null> {
+  const now = Date.now();
   const hit = rssXmlCache.get(rssUrl);
-  if (hit && hit.expires > Date.now()) return hit.xml;
-  let res: Response;
+  if (hit && now - hit.fetchedAt < RSS_FRESH_MS) return hit.xml;
+
+  let xml: string | null = null;
   try {
     assertSafeFetchUrl(rssUrl);
-    res = await fetch(rssUrl, {
+    const res = await fetch(rssUrl, {
       headers: { 'User-Agent': process.env.APP_NAME ?? 'boostmebitch/0.1' },
       next: { revalidate: 60 },
       signal: AbortSignal.timeout(8000),
     });
+    if (res.ok) xml = await res.text();
   } catch {
-    return null;
+    // fall through to the stale-on-error path
   }
-  if (!res.ok) return null;
-  const xml = await res.text();
-  rssXmlCache.set(rssUrl, { xml, expires: Date.now() + RSS_XML_TTL_MS });
-  return xml;
+
+  if (xml != null) {
+    rssXmlCache.set(rssUrl, { xml, fetchedAt: now });
+    return xml;
+  }
+  // Fetch failed or returned non-2xx — serve the last good copy if it's still
+  // within the hard stale window, otherwise give up.
+  if (hit && now - hit.fetchedAt < RSS_STALE_MS) return hit.xml;
+  return null;
 }
 
 // PI's /episodes/live only indexes currently-broadcasting items; pending


### PR DESCRIPTION
Five QoS-focused latency/resilience improvements on the hot loading paths. No new dependencies; no schema or API-shape changes. Two commits.

## 1. Dedupe the `/api/feed` RSS fetch (`lib/pi.ts`)
`/api/feed` parsed the same publisher RSS feed **twice per request** — once in `getRssEpisodeEnrichment` (socialInteract / show notes / track order) and once in `getLiveItemsFromRss` (live items) — and the route `await`s them serially, so the feed was downloaded back-to-back. Both now route through a shared `fetchFeedXml(rssUrl)` helper with an in-memory cache, so the second call is an instant hit and repeat requests for the same feed reuse the body.

## 2. Persistent shared Nostr pool (`lib/nostr/pool.ts`)
`withPool` created and closed a fresh `SimplePool` on **every** read query and publish, discarding relay WebSocket connections each time so the next query paid a full TLS+WS handshake to up to 20 relays. It now hands out one lazily-created, long-lived shared pool (nostr-tools' intended usage; it reconnects dropped relays on its own). `withExtraRelays` still tears down its one-off hint relays, keeping the persistent connection set bounded.

## 3. Relay health scoring (`lib/nostr/relay-health.ts`)
A relay in the union that's unreachable or AUTH-gated otherwise padded every feed query out to the full `FEED_QUERY_MAX_WAIT_MS`. `warmRelays()` connects the candidate relays via `pool.ensureRelay` (a no-op for already-open sockets on the shared pool) with a 3s probe budget, drops the ones that fail, and queries only the live set. Repeated failures penalty-box a relay with exponential backoff (60s → 10m); a successful connect clears the score. Never returns an empty set.

## 4. Stale-on-error RSS cache (`lib/pi.ts`)
`fetchFeedXml` now has a two-tier window: serve fresh within 60s, and if a refetch fails past that, serve the last-known-good copy within a 10-minute hard window instead of blanking the feed's live items / enrichment on a transient publisher outage.

## 5. Race feed relays / resolve on quiescence (`lib/nostr/discover.ts`, `event-queries.ts`)
The three broad feed scans (per-podcast, per-episode, global) moved off `pool.querySync` — which waits for the slowest relay or the full `maxWait` and returns empty when one stalls — onto `collectEventsByAuthors`, which returns partial results and now takes a quiet-period early resolve (`FEED_QUIET_MS` = 2500ms): once events start arriving, the scan resolves when the live relays stop trickling rather than waiting out a connected-but-stalled relay. Combined with #3, one slow/dead relay can no longer pin or empty the union.

## Behavioral notes
- **#2** keeps a small, bounded set of relay sockets open for the tab's lifetime — the intended win; `withExtraRelays` prevents one-off hint relays from accumulating. First place to look if relay-connection behavior ever seems off.
- **#3/#5** trade a small completeness margin for latency: a connected-but-very-slow relay's late, unique events can be cut by the quiet period. Mitigated by stale-while-revalidate (the next refresh catches them) and the generous 2.5s quiet window vs. the 8s ceiling.

## Verification
`npm run typecheck`, `npm run lint`, and `npm run build` all pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)