### PR TITLE
Add Picture-in-Picture for video streams + Media Session controls

### DIFF
--- a/components/fullscreen-player.tsx
+++ b/components/fullscreen-player.tsx
@@ -7,7 +7,7 @@ import { chapterState, buildChapterNav, type ChapterEntry } from '@/lib/chapters
 import { ChapterTicks, ChapterLabel } from './chapter-ui';
 import type { Podcast } from '@/lib/types';
 import { streamNaddr, parseStreamId, isLiveStreamId } from '@/lib/nostr';
-import { BoltIcon, ShareIcon } from './icons';
+import { BoltIcon, ShareIcon, PipIcon } from './icons';
 import { hasValueRecipients, isMusicMedium, stripHtml } from '@/lib/util';
 import { EpisodeSocialThread } from './episode-social-thread';
 import { PodcastCover } from './podcast-cover';
@@ -147,6 +147,8 @@ export function FullscreenPlayer({
   audioRef,
   videoNode,
   isVideo,
+  pipAvailable,
+  onPip,
   chapters,
   chaptersLoading,
   onClose,
@@ -157,6 +159,8 @@ export function FullscreenPlayer({
   audioRef: RefObject<HTMLAudioElement | null>;
   videoNode: HtmlPortalNode | null;
   isVideo: boolean;
+  pipAvailable: boolean;
+  onPip: () => void;
   // Fetched once by <Player> and passed down (so it isn't fetched twice).
   chapters: ChapterEntry[] | null;
   chaptersLoading: boolean;
@@ -276,6 +280,17 @@ export function FullscreenPlayer({
                   {isPlaying ? '❚❚' : '▶'}
                 </span>
               </button>
+              {pipAvailable && (
+                <button
+                  type="button"
+                  onClick={onPip}
+                  aria-label="Picture-in-Picture"
+                  title="Picture-in-Picture"
+                  className="absolute top-2 right-2 z-10 flex items-center justify-center w-9 h-9 rounded-lg bg-ink/55 text-bone backdrop-blur-sm hover:bg-ink/75 transition-colors"
+                >
+                  <PipIcon className="w-5 h-5" />
+                </button>
+              )}
             </div>
           ) : (
             <div className="w-full max-w-md sm:max-w-lg lg:max-w-xl aspect-square">

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -52,6 +52,24 @@ export function ShareIcon({ className = 'w-4 h-4' }: { className?: string }) {
   );
 }
 
+export function PipIcon({ className = 'w-4 h-4' }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={`flex-shrink-0 ${className}`}
+    >
+      <rect x="2" y="4" width="20" height="16" rx="2" />
+      <rect x="12" y="11" width="8" height="6" rx="1" fill="currentColor" stroke="none" />
+    </svg>
+  );
+}
+
 export function MoonIcon({ className = 'w-4 h-4' }: { className?: string }) {
   return (
     <svg

--- a/components/player.tsx
+++ b/components/player.tsx
@@ -9,11 +9,11 @@ import {
 import type Hls from 'hls.js';
 import { useApp } from '@/lib/store';
 import { fmt } from '@/lib/format';
-import { hasValueRecipients, isHlsUrl, isMusicMedium } from '@/lib/util';
+import { hasValueRecipients, isHlsUrl, isMusicMedium, pipSupported, togglePip } from '@/lib/util';
 import { useChapters, chapterUrlFor, chapterState, buildChapterNav } from '@/lib/chapters';
 import { ChapterTicks, ChapterLabel } from './chapter-ui';
 import { BoostModal } from './boost-modal';
-import { BoltIcon } from './icons';
+import { BoltIcon, PipIcon } from './icons';
 import { FullscreenPlayer } from './fullscreen-player';
 import { TransportControls } from './transport-controls';
 
@@ -24,6 +24,9 @@ export function Player() {
   const [duration, setDuration] = useState(0);
   const [boostOpen, setBoostOpen] = useState(false);
   const [audioErr, setAudioErr] = useState<string | null>(null);
+  // Whether the active <video> can enter Picture-in-Picture (HLS streams only —
+  // the native <audio> can't). Recomputed per item; gates the PiP button.
+  const [pipOk, setPipOk] = useState(false);
   // Last whole second pushed to the store. timeupdate fires ~4×/sec, but
   // every consumer renders whole seconds (fmt(), step=1 seek bars, chapter
   // highlighting) — gating on the floor cuts store-driven re-renders to 1 Hz.
@@ -172,6 +175,83 @@ export function Player() {
     else el.pause();
   }, [isPlaying]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // PiP only applies to the HLS <video>; recompute when the item changes. The
+  // <video> is always mounted (in the portal) so video.current is live here.
+  useEffect(() => {
+    setPipOk(isHls && pipSupported(video.current));
+  }, [isHls, current?.episode.id]);
+
+  function requestPip() {
+    void togglePip(video.current);
+  }
+
+  // Media Session — OS lock-screen / notification transport + metadata. Wires
+  // the system media controls to the same store actions the in-app UI uses, so
+  // play/pause/skip and (for podcasts) lock-screen scrubbing work with the
+  // screen off. Handlers read from the store via getState so this runs once.
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) return;
+    const ms = navigator.mediaSession;
+    const seekActive = (t: number) => {
+      const el = isHlsRef.current ? video.current : audio.current;
+      if (el) el.currentTime = t;
+      lastTick.current = Math.floor(t);
+      setPosition(t);
+    };
+    const handlers: [MediaSessionAction, MediaSessionActionHandler][] = [
+      ['play', () => setPlaying(true)],
+      ['pause', () => setPlaying(false)],
+      ['previoustrack', () => useApp.getState().playPrev()],
+      ['nexttrack', () => useApp.getState().playNext()],
+      ['seekbackward', (d) => seekActive(Math.max(0, useApp.getState().positionSec - (d.seekOffset || 10)))],
+      ['seekforward', (d) => seekActive(useApp.getState().positionSec + (d.seekOffset || 10))],
+      ['seekto', (d) => { if (d.seekTime != null) seekActive(d.seekTime); }],
+    ];
+    for (const [action, handler] of handlers) {
+      try { ms.setActionHandler(action, handler); } catch { /* unsupported action — skip */ }
+    }
+    return () => {
+      for (const [action] of handlers) {
+        try { ms.setActionHandler(action, null); } catch { /* skip */ }
+      }
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Metadata for the lock-screen / notification (title, podcast, artwork).
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) return;
+    if (!current) { navigator.mediaSession.metadata = null; return; }
+    const { episode, podcast } = current;
+    const art = episode.image || podcast.image || podcast.artwork;
+    navigator.mediaSession.metadata = new MediaMetadata({
+      title: episode.title,
+      artist: podcast.title,
+      album: podcast.title,
+      artwork: art ? [{ src: art }] : undefined,
+    });
+  }, [current?.episode.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Reflect play/pause to the OS so the lock-screen button shows the right state.
+  useEffect(() => {
+    if (typeof navigator !== 'undefined' && 'mediaSession' in navigator) {
+      navigator.mediaSession.playbackState = isPlaying ? 'playing' : 'paused';
+    }
+  }, [isPlaying]);
+
+  // Lock-screen scrub bar. Skipped for live streams (no finite duration).
+  useEffect(() => {
+    if (typeof navigator === 'undefined' || !('mediaSession' in navigator)) return;
+    if (typeof navigator.mediaSession.setPositionState !== 'function') return;
+    if (!duration || !isFinite(duration)) return;
+    try {
+      navigator.mediaSession.setPositionState({
+        duration,
+        position: Math.min(positionSec, duration),
+        playbackRate: 1,
+      });
+    } catch { /* invalid state (e.g. position > duration mid-seek) — skip */ }
+  }, [positionSec, duration]);
+
   // Single chapters fetch for the whole player — passed down to <FullscreenPlayer>
   // so it isn't fetched twice. No-ops on an empty url (music/live/no tag). Above
   // the early return for hook order.
@@ -298,6 +378,16 @@ export function Player() {
           </div>
           <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
             <TransportControls playOnly={isLive} prev={chapterNav?.prev} next={chapterNav?.next} />
+            {pipOk && (
+              <button
+                onClick={requestPip}
+                className="btn-ghost px-2"
+                title="Picture-in-Picture"
+                aria-label="Picture-in-Picture"
+              >
+                <PipIcon />
+              </button>
+            )}
             <button
               onClick={() => setBoostOpen(true)}
               disabled={!hasValue}
@@ -316,6 +406,8 @@ export function Player() {
         audioRef={audio}
         videoNode={videoNode}
         isVideo={isHls}
+        pipAvailable={pipOk}
+        onPip={requestPip}
         chapters={chapters}
         chaptersLoading={chaptersLoading}
         onClose={() => setPlayerExpanded(false)}

--- a/lib/util.ts
+++ b/lib/util.ts
@@ -31,6 +31,50 @@ export function isHlsUrl(url: string | undefined | null): boolean {
   return !!url && /\.m3u8(\?|#|$)/i.test(url);
 }
 
+// Picture-in-Picture across the two web APIs: the standard `requestPictureInPicture`
+// (Android Chrome, desktop Chrome/Edge/Firefox/Safari) and WebKit's
+// `webkitSetPresentationMode` (iOS Safari, which doesn't implement the standard
+// one). Only matters for the HLS <video> path — the native <audio> the rest of
+// the app uses can't go into PiP. PiP also keeps a stream's audio playing while
+// the app is backgrounded on mobile, so it doubles as background audio for video.
+type WebkitVideo = HTMLVideoElement & {
+  webkitSupportsPresentationMode?: (mode: string) => boolean;
+  webkitSetPresentationMode?: (mode: string) => void;
+  webkitPresentationMode?: string;
+};
+
+export function pipSupported(el: HTMLVideoElement | null): boolean {
+  if (!el || typeof document === 'undefined') return false;
+  if (document.pictureInPictureEnabled && !el.disablePictureInPicture) return true;
+  const w = el as WebkitVideo;
+  return (
+    typeof w.webkitSupportsPresentationMode === 'function' &&
+    w.webkitSupportsPresentationMode('picture-in-picture')
+  );
+}
+
+// Toggle PiP for the given <video>. Prefers the standard API, falls back to
+// WebKit. Swallows errors (a missing user gesture / not-allowed throws and is
+// not worth surfacing).
+export async function togglePip(el: HTMLVideoElement | null): Promise<void> {
+  if (!el || typeof document === 'undefined') return;
+  if (document.pictureInPictureEnabled && !el.disablePictureInPicture) {
+    try {
+      if (document.pictureInPictureElement) await document.exitPictureInPicture();
+      else await el.requestPictureInPicture();
+    } catch { /* user gesture / not-allowed — silent */ }
+    return;
+  }
+  const w = el as WebkitVideo;
+  if (typeof w.webkitSetPresentationMode === 'function') {
+    try {
+      w.webkitSetPresentationMode(
+        w.webkitPresentationMode === 'picture-in-picture' ? 'inline' : 'picture-in-picture',
+      );
+    } catch { /* silent */ }
+  }
+}
+
 // Coerce an unknown thrown value into a user-readable string. Use for the
 // fallback in `catch (e) { return { error: getErrorMessage(e, '<x> failed') } }`
 // patterns in API routes and UI handlers.


### PR DESCRIPTION
PiP for the HLS <video> path (Nostr live streams) via a button in both
the mini-bar and the fullscreen video pane. Works on Android Chrome /
desktop (standard requestPictureInPicture) and iOS Safari (WebKit
webkitSetPresentationMode), feature-detected so the button only shows
where supported. PiP also keeps a stream's audio playing while the app
is backgrounded on mobile, which is the only web mechanism for
background audio on video.

Media Session API wires OS lock-screen / notification controls to the
existing store actions: play/pause, prev/next, seek, plus metadata
(title, podcast, artwork) and a lock-screen scrub bar for podcasts.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012c9ogubZ773oXr3AJqSbuY