### PR TITLE
Add permanent /live/<npub> share links for Nostr streams

### DIFF
--- a/app/live/[npub]/page.tsx
+++ b/app/live/[npub]/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { nip19 } from 'nostr-tools';
+import {
+  fetchLatestStreamByPubkey,
+  resolveStreamV4V,
+  streamToEpisode,
+  streamToPodcast,
+  fetchProfile,
+  type NostrLiveStream,
+} from '@/lib/nostr';
+import type { ProfileMetadata } from '@/lib/nostr/auth';
+import { useApp } from '@/lib/store';
+import { NostrAuth } from '@/components/nostr-auth';
+import { Avatar } from '@/components/avatar';
+import { fmtLiveTime } from '@/lib/format';
+
+// Permanent per-host live link: `/live/<npub>`. Unlike `/stream/<naddr>` (which
+// pins one broadcast by its dTag), this resolves the host's *current* stream at
+// click time, so the URL a show puts in its bio stays valid across broadcasts —
+// each new stream gets a fresh dTag, but the host's npub never changes.
+//
+// When the host is live we open the app-global <Player> (mounted in the root
+// layout) on top, same as the /stream route. When they aren't, we render a
+// clean "not live" placeholder with their name/avatar (and a "next up" time if
+// a stream is scheduled) instead of opening anything.
+export default function LivePage() {
+  const params = useParams();
+  const router = useRouter();
+  const npub = Array.isArray(params.npub) ? params.npub[0] : (params.npub ?? '');
+  const play = useApp((s) => s.play);
+  const setPlayerExpanded = useApp((s) => s.setPlayerExpanded);
+  const playerExpanded = useApp((s) => s.playerExpanded);
+
+  const [status, setStatus] = useState<'loading' | 'open' | 'offline' | 'notfound'>('loading');
+  // The host's stream (when planned, drives the "next up" hint) + profile for
+  // the offline placeholder.
+  const [host, setHost] = useState<{ profile: ProfileMetadata | null; stream: NostrLiveStream | null }>({
+    profile: null,
+    stream: null,
+  });
+  const wasOpen = useRef(false);
+
+  useEffect(() => {
+    let pubkey = '';
+    try {
+      const decoded = nip19.decode(npub);
+      if (decoded.type === 'npub') pubkey = decoded.data;
+    } catch { /* malformed */ }
+    if (!pubkey) { setStatus('notfound'); return; }
+
+    let cancelled = false;
+    (async () => {
+      // Host profile and stream in parallel; the profile is needed whether or
+      // not they're live (placeholder + player podcast stub).
+      const profilePromise = fetchProfile(pubkey).catch(() => null);
+
+      // Retry before giving up: a cold load (no warm WS to the host relay like
+      // fountain.fm) can time out on the first query — a second/third attempt
+      // reuses the now-warm connection. Same pattern as the /stream route.
+      let stream: NostrLiveStream | null = null;
+      for (let attempt = 0; attempt < 3 && !cancelled; attempt++) {
+        if (attempt > 0) await new Promise((r) => setTimeout(r, 800));
+        stream = await fetchLatestStreamByPubkey(pubkey);
+        if (stream?.status === 'live') break; // live now — stop early
+      }
+      if (cancelled) return;
+
+      const profile = await profilePromise;
+      if (cancelled) return;
+      setHost({ profile, stream });
+
+      if (stream?.status === 'live' && stream.streamUrl) {
+        play(streamToEpisode(stream, null), streamToPodcast(stream, profile));
+        setPlayerExpanded(true);
+        setStatus('open');
+        // Enrich boost value in the background — episode.id is stable so the
+        // video/hls don't restart.
+        const value = await resolveStreamV4V(stream).catch(() => null);
+        if (!cancelled && value && useApp.getState().current?.episode.guid === stream.id) {
+          play(streamToEpisode(stream, value), streamToPodcast(stream, profile));
+        }
+      } else {
+        setStatus('offline');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [npub, play, setPlayerExpanded]);
+
+  // When the user collapses the fullscreen player, leave this page and go home —
+  // the stream keeps playing in the mini-bar (the Player lives in the layout).
+  useEffect(() => {
+    if (playerExpanded) wasOpen.current = true;
+    else if (wasOpen.current) router.push('/');
+  }, [playerExpanded, router]);
+
+  const displayName =
+    host.profile?.display_name ?? host.profile?.name ?? (npub ? npub.slice(0, 12) + '…' : 'this host');
+
+  return (
+    <>
+      {/* Mounts the Nostr session logic (identity hydration + sign-in modal) on
+          this standalone route where the home page's <NostrAuth> isn't present.
+          Hidden; the player's own "Sign in" button opens the portal'd modal. */}
+      <div className="hidden">
+        <NostrAuth />
+      </div>
+      <div
+        className="fixed inset-0 z-40 bg-ink flex flex-col items-center justify-center gap-4 text-muted px-6 text-center"
+        style={{ paddingTop: 'env(safe-area-inset-top)' }}
+      >
+        {status === 'notfound' ? (
+          <>
+            <span className="text-sm">That host link isn&apos;t valid.</span>
+            <button onClick={() => router.push('/')} className="btn-ghost">← Go home</button>
+          </>
+        ) : status === 'offline' ? (
+          <>
+            <Avatar
+              pubkey={host.stream?.pubkey ?? ''}
+              picture={host.profile?.picture}
+              name={displayName}
+              className="w-16 h-16 rounded-full"
+            />
+            <div className="flex flex-col gap-1">
+              <span className="font-display text-lg text-bone">{displayName}</span>
+              <span className="text-sm">isn&apos;t live right now.</span>
+            </div>
+            {host.stream?.status === 'planned' && host.stream.startsAt != null && (
+              <span className="text-xs text-bolt font-mono">
+                Next: {host.stream.title} — starts {fmtLiveTime(host.stream.startsAt)}
+              </span>
+            )}
+            <button onClick={() => router.push('/')} className="btn-ghost mt-1">← Browse shows</button>
+          </>
+        ) : (
+          <>
+            <span className="text-nostr animate-bolt text-3xl">●</span>
+            <span className="text-sm font-mono uppercase tracking-widest">Loading live stream…</span>
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/components/fullscreen-player.tsx
+++ b/components/fullscreen-player.tsx
@@ -6,7 +6,8 @@ import { fmt } from '@/lib/format';
 import { chapterState, buildChapterNav, type ChapterEntry } from '@/lib/chapters';
 import { ChapterTicks, ChapterLabel } from './chapter-ui';
 import type { Podcast } from '@/lib/types';
-import { streamNaddr, parseStreamId, isLiveStreamId } from '@/lib/nostr';
+import { parseStreamId, isLiveStreamId } from '@/lib/nostr';
+import { nip19 } from 'nostr-tools';
 import { BoltIcon, ShareIcon, PipIcon } from './icons';
 import { hasValueRecipients, isMusicMedium, stripHtml } from '@/lib/util';
 import { EpisodeSocialThread } from './episode-social-thread';
@@ -105,9 +106,12 @@ function EpisodeInfoPanel({
   );
 }
 
-// Copy a BMB deep link to the current item: ?stream=<naddr> for a Nostr live
-// stream (liveStreamId = `<pubkey>:<dTag>`), else ?podcast=<guid>. Clipboard-only
-// with a COPIED flip, mirroring the episode-list ShareButton.
+// Copy a BMB deep link to the current item. For a Nostr live stream
+// (liveStreamId = `<pubkey>:<dTag>`) this hands out the PERMANENT per-host
+// link `/live/<npub>` — not the per-broadcast `/stream/<naddr>` — so a show can
+// share one URL that stays valid across broadcasts (each gets a fresh dTag).
+// Otherwise ?podcast=<guid>. Clipboard-only with a COPIED flip, mirroring the
+// episode-list ShareButton.
 function ShareButton({ liveStreamId, podcast }: { liveStreamId: string | null; podcast: Podcast }) {
   const [copied, setCopied] = useState(false);
 
@@ -117,7 +121,7 @@ function ShareButton({ liveStreamId, podcast }: { liveStreamId: string | null; p
     if (liveStreamId) {
       const parsed = parseStreamId(liveStreamId);
       if (!parsed) return null;
-      return `${origin}/stream/${streamNaddr(parsed.pubkey, parsed.dTag)}`;
+      return `${origin}/live/${nip19.npubEncode(parsed.pubkey)}`;
     }
     if (podcast.podcastGuid) return `${origin}/?podcast=${podcast.podcastGuid}`;
     return null;

--- a/lib/nostr/index.ts
+++ b/lib/nostr/index.ts
@@ -98,6 +98,7 @@ export { hydrateMutes } from './mutes-hydrator';
 export {
   fetchNostrLiveStreams,
   fetchLiveStreamByAddr,
+  fetchLatestStreamByPubkey,
   streamNaddr,
   resolveStreamV4V,
   streamToEpisode,

--- a/lib/nostr/live-streams.ts
+++ b/lib/nostr/live-streams.ts
@@ -231,6 +231,66 @@ export async function fetchLiveStreamByAddr(
 }
 
 /**
+ * Fetch a host's *current* live stream by pubkey — the backing query for the
+ * permanent `/live/<npub>` share link. Unlike `fetchLiveStreamByAddr` (which
+ * pins one broadcast by its dTag), this ignores the dTag entirely so the link
+ * stays valid across broadcasts: most clients mint a fresh random dTag per
+ * stream, so a host's durable identity is their pubkey, not any one naddr.
+ *
+ * Priority: a genuinely-live stream (fresh `live` status, newest first); else
+ * the soonest upcoming `planned` stream (so the page can show a "next up" hint);
+ * else null. Ended broadcasts are never returned — we don't auto-open a dead
+ * stream behind a permanent link.
+ */
+export async function fetchLatestStreamByPubkey(
+  pubkey: string,
+  relayHints: string[] = [],
+): Promise<NostrLiveStream | null> {
+  const relays = sanitizeRelays([...relayHints, ...LIVE_STREAM_RELAYS]).slice(0, 20);
+  return withPool(relays, async (pool) => {
+    try {
+      // Query by AUTHOR only (no `#d` filter) — same reasoning as
+      // fetchLiveStreamByAddr: fountain.fm and other host relays don't honor
+      // tag filters reliably in-browser. A host has few streams, so fetch all
+      // and pick client-side.
+      const events = await pool.querySync(
+        relays,
+        { kinds: [30311], authors: [pubkey], limit: 50 },
+        { maxWait: FEED_QUERY_MAX_WAIT_MS },
+      );
+
+      // Dedupe replaceable events by NIP-33 address (newest version wins).
+      const byAddr = new Map<string, Event>();
+      for (const e of events) {
+        const dTag = e.tags.find((t) => t[0] === 'd')?.[1] ?? e.id;
+        const addr = `${e.pubkey}:${dTag}`;
+        const existing = byAddr.get(addr);
+        if (!existing || e.created_at > existing.created_at) byAddr.set(addr, e);
+      }
+
+      const liveFreshAfter = Math.floor(Date.now() / 1000) - LIVE_FRESH_SECS;
+      const streams = Array.from(byAddr.values()).map(parseNostrLiveStream);
+
+      // A fresh `live` event = broadcasting right now (clients re-publish it
+      // periodically). Newest first if the host somehow has two.
+      const live = streams
+        .filter((s) => s.status === 'live' && s.rawEvent.created_at >= liveFreshAfter)
+        .sort((a, b) => (b.startsAt ?? 0) - (a.startsAt ?? 0));
+      if (live[0]) return live[0];
+
+      // Otherwise the soonest upcoming planned stream (drives the "next up" hint
+      // on the offline placeholder).
+      const planned = streams
+        .filter((s) => s.status === 'planned')
+        .sort((a, b) => (a.startsAt ?? Infinity) - (b.startsAt ?? Infinity));
+      return planned[0] ?? null;
+    } catch {
+      return null;
+    }
+  });
+}
+
+/**
  * Resolve a ValueBlock for V4V boosts against a Nostr live stream.
  *
  * Two paths:


### PR DESCRIPTION
Live streams are kind:30311 replaceable events addressed by <pubkey>:<dTag>,
but most clients mint a fresh random dTag per broadcast — so a /stream/<naddr>
link points at one dead broadcast next time a show goes live. The host's pubkey
is the only durable handle.

- fetchLatestStreamByPubkey(pubkey): query kind:30311 by author only (no dTag
  filter), return the host's current live stream, else the soonest upcoming
  planned one, else null. Ended broadcasts never returned.
- app/live/[npub]/page.tsx: resolve the host's current stream at click time.
  Live -> open the player (same bridge as /stream). Not live -> a clean "not
  live" placeholder with the host's avatar/name and a "next up" time when a
  stream is scheduled.
- Fullscreen SHARE button on a live stream now copies the permanent
  /live/<npub> link instead of a per-broadcast /stream/<naddr>.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JxWJjxZGMaY9yTEG2XRPsY